### PR TITLE
Feature: Bidirectional(ish) inference

### DIFF
--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -16,6 +16,7 @@ executable amuletml
                      , syb >= 0.7 && < 0.8
                      , base >= 4.9 && < 4.11
                      , text >= 1.2 && < 1.3
+                     , lens >= 4.15 && < 4.16
                      , parsec >= 3.1 && < 3.2
                      , monad-gen >= 0.3 && < 0.4
                      , containers >= 0.5 && < 0.6

--- a/default.nix
+++ b/default.nix
@@ -4,8 +4,17 @@ let
 
   inherit (nixpkgs) pkgs;
 
-  f = { mkDerivation, base, syb, containers, monad-gen, mtl
-      , parsec, stdenv, text, transformers, pretty-show
+  f = { mkDerivation, stdenv
+      , mtl
+      , syb
+      , base
+      , text
+      , parsec
+      , monad-gen
+      , containers
+      , pretty-show
+      , transformers
+      , lens
       }:
       mkDerivation {
         pname = "amuletml";
@@ -15,7 +24,7 @@ let
         isExecutable = true;
         executableHaskellDepends = [
           base syb containers monad-gen mtl parsec text transformers
-          pretty-show # This is here for ghci prettiness
+          pretty-show lens # This is here for ghci prettiness
         ];
         homepage = "https://amulet.ml";
         description = "A functional programming language";

--- a/src/Control/Monad/Infer.hs
+++ b/src/Control/Monad/Infer.hs
@@ -6,7 +6,7 @@
   , StandaloneDeriving
   , MultiParamTypeClasses
   , OverloadedStrings
-  , ConstraintKinds#-}
+  #-}
 module Control.Monad.Infer
   ( module M
   , TypeError(..)

--- a/src/Core/Optimise.hs
+++ b/src/Core/Optimise.hs
@@ -88,7 +88,7 @@ extendVars vs = local (\s -> s { vars = foldr (\(v, _, e) m -> Map.insert v e m)
 newtype TransformPass = Pass { runPass :: CoTerm -> Trans CoTerm }
 
 instance Semigroup TransformPass where
-  Pass f <> Pass g = Pass (\x -> g x >>= f)
+  Pass f <> Pass g = Pass (g >=> f)
   {-# INLINE [0] (<>) #-}
 
 instance Monoid TransformPass where

--- a/src/Core/Optimise/Match.hs
+++ b/src/Core/Optimise/Match.hs
@@ -8,6 +8,8 @@ import Data.Monoid
 import Data.Maybe
 import Data.List
 
+import Control.Monad
+
 import Syntax (Var, Resolved)
 import Core.Optimise
 
@@ -44,7 +46,7 @@ matchKnownConstr = pass go where
   canWe (CotTyApp x _) = canWe x
   canWe (CotExtend t xs) = do
     t' <- canWe t
-    xs' <- mapM (canWe . thd3) xs
+    xs' <- traverse (canWe . thd3) xs
     pure (t' && and xs')
   canWe CotLit{} = pure True
   canWe _ = pure False
@@ -66,7 +68,7 @@ matchKnownConstr = pass go where
   match (CopExtend p xs) (CotExtend e ys) = match p e <> rows where
     xs' = sortOn fst xs
     ys' = sortOn fst (map (\(x, _, y) -> (x, y)) ys)
-    rows = fmap concat $ sequence (zipWith mr xs' ys')
+    rows = concat <$> zipWithM mr xs' ys'
     mr (t, p) (t', e)
       | t == t' = match p e
       | otherwise = Nothing

--- a/src/Data/Triple.hs
+++ b/src/Data/Triple.hs
@@ -4,6 +4,7 @@ module Data.Triple
   , thd3
   , trimap, first3, second3, third3
   , trimapA, first3A, second3A, third3A
+  , firstA, secondA
   ) where
 
 fst3 :: (a, b, c) -> a
@@ -39,3 +40,8 @@ second3A f = trimapA pure f pure
 third3A :: Applicative f => (c -> f c') -> (a, b, c) -> f (a, b, c')
 third3A = trimapA pure pure
 
+firstA :: Applicative f => (a -> f a') -> (a, b) -> f (a', b)
+firstA f (x, y) = (,) <$> f x <*> pure y
+
+secondA :: Applicative f => (b -> f b') -> (a, b) -> f (a, b')
+secondA f (x, y) = (,) <$> pure x <*> f y

--- a/src/Data/VarSet.hs
+++ b/src/Data/VarSet.hs
@@ -35,7 +35,7 @@ difference = coerce Set.difference
 
 singleton :: Var Resolved -> Set
 singleton (TgName _ x) = coerce (Set.singleton x)
-singleton _ = coerce (Set.empty)
+singleton _ = coerce Set.empty
 
 delete :: Var Resolved -> Set -> Set
 delete (TgName _ x) set = coerce (Set.delete x (coerce set))

--- a/src/Errors.hs
+++ b/src/Errors.hs
@@ -91,6 +91,12 @@ instance Pretty TypeError where
   pprint (IllegalTypeApp ex ta _)
     = body 1 [ "Illegal type application " <+> verbatim ex
              , bullet "because of type " <+> verbatim ta ]
+  pprint (EscapedSkolems esc left right) =
+    body 1 [ "Can not use type " <+> verbatim left <+> " as a stand-in for type " <+> verbatim right
+           , "because " <+> verbatim left <+> " is insufficiently polymorphic."
+           , pprint ""
+           , pprint "Namely, the following skolem type variables would escape:"
+           , "   " <+> interleave ", " esc ]
 
 instance Pretty ResolveError where
   pprint (R.NotInScope e) = "Variable not in scope: "

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -263,7 +263,7 @@ tyVar :: Parser (Var Parsed)
 tyVar = lexeme $ do
   _ <- char '\''
   x <- Tok.identStart style
-  (Name . T.pack . (x:)) <$> many (Tok.identLetter style)
+  Name . T.pack . (x:) <$> many (Tok.identLetter style)
 
 name :: Parser (Var Parsed)
 name = Name . T.pack <$> identifier

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE FlexibleInstances, FlexibleContexts, UndecidableInstances #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies, DataKinds #-}
-{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveDataTypeable, TemplateHaskell #-}
 module Syntax where
 
 import Pretty
@@ -17,6 +17,8 @@ import Data.Foldable
 import Data.Typeable
 import Data.Triple
 import Data.Data
+
+import Control.Lens
 
 newtype Parsed = Parsed Parsed deriving Data
 newtype Resolved = Resolved Resolved deriving Data
@@ -83,6 +85,7 @@ data Expr p
 
   -- Explicit type application
   | TypeApp (Expr p) (Type p) (Ann p)
+
 
 deriving instance (Eq (Var p), Eq (Ann p)) => Eq (Expr p)
 deriving instance (Show (Var p), Show (Ann p)) => Show (Expr p)
@@ -300,6 +303,10 @@ instance Pretty (Span, Type Typed) where
 
 unTvName :: Var Typed -> Var Resolved
 unTvName (TvName x) = x
+
+makePrisms ''Expr
+makePrisms ''Type
+
 
 {- Note [1]: Tuple types vs tuple patterns/values
 

--- a/src/Types/Infer.hs
+++ b/src/Types/Infer.hs
@@ -37,12 +37,6 @@ inferProgram ct = fmap fst <$> runInfer builtinsEnv (inferAndCheck ct) where
       xs@(_:_) -> throwError (FoundHole xs)
       [] -> pure (prg', env)
 
-mkTT :: (Show (Var p), Show (Ann p)) => Type p -> [Type p] -> Type p
-mkTT x xs = TyTuple x (go xs) where
-  go [] = error $ "mkTT fucked up: " ++ show x ++ " " ++ show xs
-  go [x] = x
-  go (x:xs) = TyTuple x (go xs)
-
 mkTyApps :: Applicative f
          => Expr Resolved
          -> Map.Map (Var Typed) (Type Typed)

--- a/src/Types/Infer.hs
+++ b/src/Types/Infer.hs
@@ -1,6 +1,5 @@
-{-# OPTIONS_GHC -Wno-missing-local-signatures #-}
 {-# LANGUAGE FlexibleContexts, OverloadedStrings, TupleSections, GADTs #-}
-{-# LANGUAGE ScopedTypeVariables, ViewPatterns #-}
+{-# LANGUAGE ScopedTypeVariables, ViewPatterns, RankNTypes #-}
 module Types.Infer
   ( inferProgram
   , builtinsEnv
@@ -12,23 +11,22 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import Data.Traversable
-import Data.Span (Span)
 import Data.Generics
-import Data.Foldable
+import Data.Triple
+import Data.List (sort)
 
 import Control.Monad.Infer
-import Control.Arrow (first, (&&&))
-
+import Control.Arrow (first)
 import Syntax.Subst
 import Syntax.Raise
 import Syntax
 
+import Types.Infer.Pattern
+import Types.Infer.Builtin
 import Types.Wellformed
 import Types.Unify
 import Types.Holes
 import Types.Kinds
-
-import Pretty (prettyPrint)
 
 -- Solve for the types of lets in a program
 inferProgram :: MonadGen Int m => [Toplevel Resolved] -> m (Either TypeError ([Toplevel Typed], Env))
@@ -38,53 +36,6 @@ inferProgram ct = fmap fst <$> runInfer builtinsEnv (inferAndCheck ct) where
     case findHoles prg' of
       xs@(_:_) -> throwError (FoundHole xs)
       [] -> pure (prg', env)
-
-tyUnit, tyBool, tyInt, tyString :: Type Typed
-tyInt = TyCon (TvName (TgInternal "int"))
-tyString = TyCon (TvName (TgInternal "string"))
-tyBool = TyCon (TvName (TgInternal "bool"))
-tyUnit = TyCon (TvName (TgInternal "unit"))
-
-forall :: [Var p] -> Type p -> Type p
-forall = TyForall
-
-app, arr :: Type p -> Type p -> Type p
-arr = TyArr
-app = TyApp
-
-var, con :: Var p -> Type p
-var = TyVar
-con = TyCon
-
-builtinsEnv :: Env
-builtinsEnv = Env (Map.fromList ops) (Map.fromList tps) where
-  op :: T.Text -> Type Typed -> (Var Resolved, Type Typed)
-  op x t = (TgInternal x, t)
-  tp :: T.Text -> (Var Resolved, Kind Typed)
-  tp x = (TgInternal x, KiStar)
-
-  boolOp = tyBool `arr` (tyBool `arr` tyBool)
-  intOp = tyInt `arr` (tyInt `arr` tyInt)
-  stringOp = tyString `arr` (tyString `arr` tyString)
-  intCmp = tyInt `arr` (tyInt `arr` tyBool)
-
-  cmp = forall [name] $ var name `arr` (var name `arr` tyBool)
-    where name = TvName (TgInternal "a")-- TODO: This should use TvName/TvFresh instead
-  ops = [ op "+" intOp, op "-" intOp, op "*" intOp, op "/" intOp, op "**" intOp
-        , op "^" stringOp
-        , op "<" intCmp, op ">" intCmp, op ">=" intCmp, op "<=" intCmp
-        , op "==" cmp, op "<>" cmp
-        , op "||" boolOp, op "&&" boolOp ]
-  tps :: [(Var Resolved, Kind Typed)]
-  tps = [ tp "int", tp "string", tp "bool", tp "unit" ]
-
-unify :: MonadInfer Typed m => Expr Resolved -> Type Typed -> Type Typed -> m ()
-unify e a b = tell [ConUnify (raiseE TvName (id &&& const undefined) e) a b]
-
-itIs :: Monad m
-     => ((Span, Type Typed) -> f Typed)
-     -> Span -> Type Typed -> m (f Typed, Type Typed)
-itIs f a t = pure (f (a, t), t)
 
 mkTT :: (Show (Var p), Show (Ann p)) => Type p -> [Type p] -> Type p
 mkTT x xs = TyTuple x (go xs) where
@@ -104,114 +55,101 @@ mkTyApps (VarRef k a) mp ot@(TyForall vs _) nt = do
   pure (insts (map (mp Map.!) vs) ot (VarRef (TvName k) (a, nt)), nt)
 mkTyApps _ _ _ _ = undefined
 
-infer :: MonadInfer Typed m => Expr Resolved -> m (Expr Typed, Type Typed)
-infer expr
-  = case expr of
-      VarRef k a -> do
-        (inst, old, new) <- lookupTy' k
-        if Map.null inst
-           then itIs (VarRef (TvName k)) a new
-           else mkTyApps expr inst old new
-      Hole v ann -> itIs (Hole (TvName v)) ann =<< freshTV
-      Literal c a -> case c of
-        LiStr _ -> pure (Literal c (a, tyString), tyString)
-        LiUnit  -> pure (Literal c (a, tyUnit), tyUnit)
-        LiBool _-> pure (Literal c (a, tyBool), tyBool)
-        LiInt _ -> pure (Literal c (a, tyInt), tyInt)
-      Fun p b a -> do
-        (p', tc, ms) <- inferPattern (unify expr) p
-        (b', tb) <- extendMany ms $ infer b
-        pure (Fun p' b' (a, TyArr tc tb), TyArr tc tb)
-      Begin [] _ -> throwError (EmptyBegin expr)
-      Begin xs a -> do
-        (xs', txs) <- unzip <$> traverse infer xs
-        pure (Begin xs' (a, last txs), last txs)
-      If c t e a -> do
-        (c', tc) <- infer c
-        (t', tt) <- infer t
-        (e', te) <- infer e
-        unify c tyBool tc
-        unify expr tt te
-        itIs (If c' t' e') a te
-      App e1 e2 a -> do
-        (e1', t1) <- infer e1
-        (e2', t2) <- infer e2
-        tv <- freshTV
-        unify expr (TyArr t2 tv) t1
-        itIs (App e1' e2') a tv
-      Let ns b ann -> do
-        ks <- for ns $ \(a, _, _) -> do
-          tv <- freshTV
-          pure (TvName a, tv)
-        extendMany ks $ do
-          (ns', ts) <- inferLetTy id ks ns
-          extendMany ts $ do
-            (b', ty) <- infer b
-            itIs (Let ns' b') ann ty
-      Match t ps a -> do
-        (t', tt) <- infer t
-        (ps', tbs) <- unzip <$> for ps
-            (\ (p, e) -> do
-              (p', pt, ks) <- inferPattern (unify expr) p
-              unify expr tt pt
-              (e', ty) <- extendMany ks (infer e)
-              pure ((p', e'), ty))
-        ty <- case tbs of
-                [] -> throwError (EmptyMatch expr)
-                [x] -> pure x
-                (ty:xs) -> do
-                  traverse_ (unify expr ty) xs
-                  pure ty
-        itIs (Match t' ps') a ty
-      BinOp l o r a -> do
-        (l', tl) <- infer l
-        (o', to) <- infer o
-        (r', tr) <- infer r
-        tv <- freshTV
-        unify expr (TyArr tl (TyArr tr tv)) to
-        itIs (BinOp l' o' r') a tv
-      Record rows a -> do
-        itps <- inferRows rows
-        let (rows', rowts) = unzip itps
-        itIs (Record rows') a (TyExactRows rowts)
-      RecordExt rec rows a -> do
-        itps <- inferRows rows
-        let (rows', newTypes) = unzip itps
-        (rec', rho) <- infer rec
-        itIs (RecordExt rec' rows') a (TyRows rho newTypes)
-      Access rec key a -> do
-        (rho, ktp) <- (,) <$> freshTV <*> freshTV
-        (rec', tp) <- infer rec
-        let rows = TyRows rho [(key, ktp)]
-        unify expr tp rows
-        itIs (Access rec' key) a ktp
-      Tuple es an -> do
-        es' <- traverse infer es
-        case es' of
-          [] -> itIs (Tuple []) an tyUnit
-          [(x', t)] -> pure (x', t)
-          ((x', t):xs) -> itIs (Tuple (x':map fst xs)) an (mkTT t (map snd xs))
-      Ascription e g an -> do
-        (e', t') <- infer e
-        (g', _) <- resolveKind g
-        unify expr t' g'
-        itIs (Ascription e' t') an g'
-      TypeApp f x an -> do
-        (f', t) <- infer f
-        (x', _) <- resolveKind x
-        case f' of
-          VarRef v _ -> do
-            tp <- asks (Map.lookup (unTvName v) . values)
-            case tp of
-              Just (normType -> TyForall (v:vs) x) -> itIs (TypeApp f' x) an (normType (TyForall vs (apply (Map.singleton v x') x)))
-              Just tp -> throwError (IllegalTypeApp expr tp x')
-              Nothing -> throwError (NotInScope (unTvName v))
-          _ -> throwError (IllegalTypeApp expr t x')
+check :: MonadInfer Typed m => Expr Resolved -> Type Typed -> m (Expr Typed)
+check expr@(VarRef k a) tp = do
+  (inst, old, new) <- lookupTy' k
+  it <- subsumes expr tp new
+  if Map.null inst
+     then pure (VarRef (TvName k) (a, it))
+     else fst <$> mkTyApps expr inst old new
+check (Hole v a) t = pure (Hole (TvName v) (a, t))
+check expr@(Literal c a) t = do
+  t' <- case c of
+    LiStr{}  -> unify expr t tyString
+    LiUnit{} -> unify expr t tyUnit
+    LiBool{} -> unify expr t tyBool
+    LiInt{}  -> unify expr t tyInt
+  pure $ Literal c (a, t')
+check ex@(Fun p b a) ty = do
+  (d, c) <- decompose ex _TyArr ty
+  (p', t, ms) <- inferPattern p
+  _ <- unify ex t d
+  b' <- extendMany ms $ check b c
+  pure (Fun p' b' (a, ty))
+check ex@(Begin [] _) _ = throwError (EmptyBegin ex)
+check (Begin xs a) t = do
+  let start = init xs
+      end = last xs
+  start' <- traverse (fmap fst . infer) start
+  end' <- check end t
+  pure (Begin (start' ++ [end']) (a, t))
+check (Let ns b an) t = do
+  ks <- for ns $ \(a, _, _) -> do
+    tv <- freshTV
+    pure (TvName a, tv)
+  extendMany ks $ do
+    (ns', ts) <- inferLetTy id ks ns
+    extendMany ts $ do
+      b' <- check b t
+      pure (Let ns' b' (an, t))
+check (If c t e an) ty = If <$> check c tyBool <*> check t ty <*> check e ty <*> pure (an, ty)
+check ex@(App f x a) ty = do
+  (f', (c, d)) <- secondA (decompose ex _TyArr) =<< infer f
+  App f' <$> check x c <*> fmap (a,) (unify ex d ty)
+check ex@(Match t ps a) ty = do
+  (t', tt) <- infer t
+  ps' <- for ps $ \(p, e) -> do
+    (p', pt, ms) <- inferPattern p
+    _ <- unify ex pt tt
+    (,) <$> pure p' <*> extendMany ms (check e ty)
+  pure (Match t' ps' (a, ty))
+check ex@(BinOp l o r a) ty = do
+  (o', to) <- infer o
+  (el, to') <- decompose ex _TyArr to
+  (er, d) <- decompose ex _TyArr to'
+  BinOp <$> check l el <*> pure o' <*> check r er <*> fmap (a,) (unify ex d ty)
+check ex@(Ascription e ty an) ty' = do
+  (e', it) <- infer e
+  (nty, _) <- resolveKind ty
+  _ <- subsumes ex it nty
+  _ <- unify ex nty ty'
+  pure (Ascription e' nty (an, nty))
+check ex@(Record rows a) ty = do
+  (rows', rowts) <- unzip <$> inferRows rows
+  Record rows' . (a,) <$> unify ex ty (TyExactRows rowts)
+check ex@(RecordExt rec rows a) ty = do
+  (rec', rho) <- infer rec
+  (rows', newts) <- unzip <$> inferRows rows
+  RecordExt rec' rows' . (a,) <$> unify ex ty (TyRows rho newts)
+check (Access rc key a) ty = do
+  rho <- freshTV
+  Access <$> check rc (TyRows rho [(key, ty)]) <*> pure key <*> pure (a, ty)
+check ex@(Tuple es an) ty = Tuple <$> go es ty <*> pure (an, ty) where
+  go [] _ = error "not a tuple"
+  go [x] t = (:[]) <$> check x t
+  go (x:xs) t = do
+    (left, right) <- decompose ex _TyTuple t
+    (:) <$> check x left <*> go xs right
+check ex@(TypeApp pf tx an) ty = do
+  (tx', _) <- resolveKind tx
+  (pf', tp) <- infer pf
+  at <- case pf' of
+    VarRef var _ -> do
+      tp <- asks (Map.lookup (unTvName var) . values)
+      case tp of
+        Just (normType -> TyForall (v:vs) x) ->
+          unify ex ty (normType (TyForall vs (apply (Map.singleton v tx') x)))
+        Just tp -> throwError (IllegalTypeApp ex tp tx')
+        Nothing -> throwError (NotInScope (unTvName var))
+    _ -> throwError (IllegalTypeApp ex tp tx')
+  pure (TypeApp pf' tx' (an, at))
+check x _ = error $ "desugarer should remove " ++ show x
 
-      LeftSection{} -> error "desugarer removes right sections"
-      RightSection{} -> error "desugarer removes left sections"
-      BothSection{} -> error "desugarer removes both-side sections"
-      AccessSection{} -> error "desugarer removes access sections"
+infer :: MonadInfer Typed m => Expr Resolved -> m (Expr Typed, Type Typed)
+infer ex = do
+  x <- freshTV
+  ex' <- check ex x
+  pure (ex', x)
 
 inferRows :: MonadInfer Typed m
           => [(T.Text, Expr Resolved)]
@@ -219,52 +157,6 @@ inferRows :: MonadInfer Typed m
 inferRows rows = for rows $ \(var', val) -> do
   (val', typ) <- infer val
   pure ((var', val'), (var', typ))
-
-inferPattern :: MonadInfer Typed m
-             => (Type Typed -> Type Typed -> m ())
-             -> Pattern Resolved
-             -> m ( Pattern Typed -- the pattern
-                  , Type Typed -- type of what the pattern matches
-                  , [(Var Typed, Type Typed)] -- captures
-                  )
-inferPattern _ (Wildcard ann) = do
-  x <- freshTV
-  pure (Wildcard (ann, x), x, [])
-inferPattern _ (Capture v ann) = do
-  x <- freshTV
-  pure (Capture (TvName v) (ann, x), x, [(TvName v, x)])
-inferPattern unify (Destructure cns ps ann)
-  | Nothing <- ps = do
-    pty <- lookupTy cns
-    pure (Destructure (TvName cns) Nothing (ann, pty), pty, [])
-  | Just p <- ps = do
-    (tup, res, _) <- constructorTy <$> lookupTy cns
-    (p', pt, pb) <- inferPattern unify p
-    unify tup pt
-    pure (Destructure (TvName cns) (Just p') (ann, res), res, pb)
-  where constructorTy :: Type Typed -> (Type Typed, Type Typed, Type Typed)
-        constructorTy t
-          | TyArr tup res <- t = (tup, res, t)
-          | otherwise = error (T.unpack (prettyPrint t))
-inferPattern unify (PRecord rows ann) = do
-  rho <- freshTV
-  (rowps, rowts, caps) <- unzip3 <$> for rows (\(var, pat) -> do
-    (p', t, caps) <- inferPattern unify pat
-    pure ((var, p'), (var, t), caps))
-  pure (PRecord rowps (ann, TyRows rho rowts), TyRows rho rowts, concat caps)
-inferPattern unify (PType p t ann) = do
-  (p', pt, vs) <- inferPattern unify p
-  (t', _) <- resolveKind t
-  unify pt t'
-  case p' of
-    Capture v _ -> pure (PType p' t' (ann, t'), t', [(v, t')])
-    _ -> pure (PType p' t' (ann, t'), t', vs)
-inferPattern unify (PTuple elems ann)
-  | [] <- elems = pure (PTuple [] (ann, tyUnit), tyUnit, [])
-  | [x] <- elems = inferPattern unify x
-  | otherwise = do
-    (ps, t:ts, cps) <- unzip3 <$> traverse (inferPattern unify) elems
-    pure (PTuple ps (ann, mkTT t ts), mkTT t ts, concat cps)
 
 inferProg :: MonadInfer Typed m
           => [Toplevel Resolved] -> m ([Toplevel Typed], Env)
@@ -286,7 +178,7 @@ inferProg (ForeignVal v d t ann:prg) = do
       inferProg prg
 inferProg (TypeDecl n tvs cs:prg) = do
   kind <- resolveTyDeclKind n tvs cs
-  let retTy = foldl app (con (TvName n)) (map (var . TvName) tvs)
+  let retTy = foldl TyApp (TyCon (TvName n)) (map (TyVar . TvName) tvs)
    in extendKind (TvName n, kind) $ do
      (ts, cs') <- unzip <$> for cs (\con ->
        inferCon retTy con `catchError` \x -> throwError (ArisingFrom x con))
@@ -294,7 +186,6 @@ inferProg (TypeDecl n tvs cs:prg) = do
        consFst (TypeDecl (TvName n) (map TvName tvs) cs') $
          inferProg prg
 inferProg [] = asks ([],)
-
 
 inferCon :: MonadInfer Typed m
          => Type Typed
@@ -319,7 +210,7 @@ inferLetTy _ ks [] = pure ([], ks)
 inferLetTy closeOver ks ((va, ve, vann):xs) = extendMany ks $ do
   ((ve', ty), c) <- listen (infer ve) -- See note [1]
   cur <- gen
-  (x, vt) <- case solve cur mempty c of
+  (x, vt) <- case solve cur mempty (sort c) of
     Left e -> throwError e
     Right x -> pure (x, closeOver (apply x ty))
   let r (a, t) = (a, apply x t)

--- a/src/Types/Infer/Builtin.hs
+++ b/src/Types/Infer/Builtin.hs
@@ -52,10 +52,10 @@ subsumes e a b = do
 decompose :: ( Reasonable f p
              , MonadInfer Typed m )
           => f p
-          -> (Prism' (Type Typed) (Type Typed, Type Typed))
+          -> Prism' (Type Typed) (Type Typed, Type Typed)
           -> Type Typed
           -> m (Type Typed, Type Typed)
-decompose r p t = do
+decompose r p t =
   case t ^? p of
     Just ts -> pure ts
     Nothing -> do

--- a/src/Types/Infer/Builtin.hs
+++ b/src/Types/Infer/Builtin.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE OverloadedStrings, FlexibleContexts, RankNTypes #-}
+module Types.Infer.Builtin where
+
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as T
+
+import Control.Monad.Infer
+import Control.Lens
+
+import Syntax
+
+tyUnit, tyBool, tyInt, tyString :: Type Typed
+tyInt = TyCon (TvName (TgInternal "int"))
+tyString = TyCon (TvName (TgInternal "string"))
+tyBool = TyCon (TvName (TgInternal "bool"))
+tyUnit = TyCon (TvName (TgInternal "unit"))
+
+builtinsEnv :: Env
+builtinsEnv = Env (Map.fromList ops) (Map.fromList tps) where
+  op :: T.Text -> Type Typed -> (Var Resolved, Type Typed)
+  op x t = (TgInternal x, t)
+  tp :: T.Text -> (Var Resolved, Kind Typed)
+  tp x = (TgInternal x, KiStar)
+
+  boolOp = tyBool `TyArr` (tyBool `TyArr` tyBool)
+  intOp = tyInt `TyArr` (tyInt `TyArr` tyInt)
+  stringOp = tyString `TyArr` (tyString `TyArr` tyString)
+  intCmp = tyInt `TyArr` (tyInt `TyArr` tyBool)
+
+  cmp = TyForall [name] $ TyVar name `TyArr` (TyVar name `TyArr` tyBool)
+    where name = TvName (TgInternal "a")-- TODO: This should use TvName/TvFresh instead
+  ops = [ op "+" intOp, op "-" intOp, op "*" intOp, op "/" intOp, op "**" intOp
+        , op "^" stringOp
+        , op "<" intCmp, op ">" intCmp, op ">=" intCmp, op "<=" intCmp
+        , op "==" cmp, op "<>" cmp
+        , op "||" boolOp, op "&&" boolOp ]
+  tps :: [(Var Resolved, Kind Typed)]
+  tps = [ tp "int", tp "string", tp "bool", tp "unit" ]
+
+unify, subsumes :: ( Reasonable f p
+                   , MonadInfer Typed m )
+                => f p
+                -> Type Typed
+                -> Type Typed -> m (Type Typed)
+unify e a b = do
+  tell [ConUnify (BecauseOf e) a b]
+  pure b
+subsumes e a b = do
+  tell [ConSubsume (BecauseOf e) a b]
+  pure b
+
+decompose :: ( Reasonable f p
+             , MonadInfer Typed m )
+          => f p
+          -> (Prism' (Type Typed) (Type Typed, Type Typed))
+          -> Type Typed
+          -> m (Type Typed, Type Typed)
+decompose r p t = do
+  case t ^? p of
+    Just ts -> pure ts
+    Nothing -> do
+      (a, b) <- (,) <$> freshTV <*> freshTV
+      _ <- unify r t (p # (a, b))
+      pure (a, b)

--- a/src/Types/Infer/Pattern.hs
+++ b/src/Types/Infer/Pattern.hs
@@ -1,79 +1,15 @@
-{-# LANGUAGE FlexibleContexts, OverloadedStrings, TupleSections, GADTs #-}
+{-# LANGUAGE FlexibleContexts, OverloadedStrings, GADTs #-}
 {-# LANGUAGE ScopedTypeVariables, ViewPatterns, RankNTypes #-}
 module Types.Infer.Pattern where
 
-import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
-import qualified Data.Text as T
 import Data.Traversable
-import Data.Generics
-import Data.Triple
-import Data.List (sort)
-import Data.Span
 
 import Control.Monad.Infer
-import Control.Arrow (first, (&&&))
 
-import Syntax.Subst
-import Syntax.Raise
 import Syntax
 
 import Types.Infer.Builtin
-import Types.Wellformed
-import Types.Unify
-import Types.Holes
 import Types.Kinds
-
-import Control.Lens
-
-import Pretty (prettyPrint)
-
--- inferPattern :: MonadInfer Typed m
---              => (Type Typed -> Type Typed -> m a)
---              -> Pattern Resolved
---              -> m ( Pattern Typed -- the pattern
---                   , Type Typed -- type of what the pattern matches
---                   , [(Var Typed, Type Typed)] -- captures
---                   )
--- inferPattern _ (Wildcard ann) = do
---   x <- freshTV
---   pure (Wildcard (ann, x), x, [])
--- inferPattern _ (Capture v ann) = do
---   x <- freshTV
---   pure (Capture (TvName v) (ann, x), x, [(TvName v, x)])
--- inferPattern unify (Destructure cns ps ann)
---   | Nothing <- ps = do
---     pty <- lookupTy cns
---     pure (Destructure (TvName cns) Nothing (ann, pty), pty, [])
---   | Just p <- ps = do
---     (tup, res, _) <- constructorTy <$> lookupTy cns
---     (p', pt, pb) <- inferPattern unify p
---     _ <- unify tup pt
---     pure (Destructure (TvName cns) (Just p') (ann, res), res, pb)
---   where constructorTy :: Type Typed -> (Type Typed, Type Typed, Type Typed)
---         constructorTy t
---           | TyArr tup res <- t = (tup, res, t)
---           | otherwise = error (T.unpack (prettyPrint t))
--- inferPattern unify (PRecord rows ann) = do
---   rho <- freshTV
---   (rowps, rowts, caps) <- unzip3 <$> for rows (\(var, pat) -> do
---     (p', t, caps) <- inferPattern unify pat
---     pure ((var, p'), (var, t), caps))
---   pure (PRecord rowps (ann, TyRows rho rowts), TyRows rho rowts, concat caps)
--- inferPattern unify (PType p t ann) = do
---   (p', pt, vs) <- inferPattern unify p
---   (t', _) <- resolveKind t
---   _ <- unify pt t'
---   case p' of
---     Capture v _ -> pure (PType p' t' (ann, t'), t', [(v, t')])
---     _ -> pure (PType p' t' (ann, t'), t', vs)
--- inferPattern unify (PTuple elems ann)
---   | [] <- elems = pure (PTuple [] (ann, tyUnit), tyUnit, [])
---   | [x] <- elems = inferPattern unify x
---   | otherwise = do
---     (ps, t:ts, cps) <- unzip3 <$> traverse (inferPattern unify) elems
---     pure (PTuple ps (ann, mkTT t ts), mkTT t ts, concat cps)
-
 
 inferPattern :: MonadInfer Typed m
              => Pattern Resolved
@@ -104,7 +40,8 @@ checkPattern ex@(Destructure con ps ann) ty =
       ty <- lookupTy con
       (c, d) <- decompose ex _TyArr ty
       (ps', b) <- checkPattern p c
-      pure (Destructure (TvName con) (Just ps') (ann, ty), b)
+      _ <- unify ex ty d
+      pure (Destructure (TvName con) (Just ps') (ann, d), b)
 checkPattern pt@(PRecord rows ann) ty = do
   rho <- freshTV
   (rowps, rowts, caps) <- unzip3 <$> for rows (\(var, pat) -> do
@@ -117,6 +54,7 @@ checkPattern pt@(PTuple elems ann) ty =
       go (x:xs) t = do
         (left, right) <- decompose pt _TyTuple t
         (:) <$> checkPattern x left <*> go xs right
+      go [] _ = error "malformed tuple in checkPattern"
     in case elems of
       [] -> do
         _ <- unify pt ty tyUnit

--- a/src/Types/Infer/Pattern.hs
+++ b/src/Types/Infer/Pattern.hs
@@ -1,0 +1,134 @@
+{-# LANGUAGE FlexibleContexts, OverloadedStrings, TupleSections, GADTs #-}
+{-# LANGUAGE ScopedTypeVariables, ViewPatterns, RankNTypes #-}
+module Types.Infer.Pattern where
+
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import qualified Data.Text as T
+import Data.Traversable
+import Data.Generics
+import Data.Triple
+import Data.List (sort)
+import Data.Span
+
+import Control.Monad.Infer
+import Control.Arrow (first, (&&&))
+
+import Syntax.Subst
+import Syntax.Raise
+import Syntax
+
+import Types.Infer.Builtin
+import Types.Wellformed
+import Types.Unify
+import Types.Holes
+import Types.Kinds
+
+import Control.Lens
+
+import Pretty (prettyPrint)
+
+-- inferPattern :: MonadInfer Typed m
+--              => (Type Typed -> Type Typed -> m a)
+--              -> Pattern Resolved
+--              -> m ( Pattern Typed -- the pattern
+--                   , Type Typed -- type of what the pattern matches
+--                   , [(Var Typed, Type Typed)] -- captures
+--                   )
+-- inferPattern _ (Wildcard ann) = do
+--   x <- freshTV
+--   pure (Wildcard (ann, x), x, [])
+-- inferPattern _ (Capture v ann) = do
+--   x <- freshTV
+--   pure (Capture (TvName v) (ann, x), x, [(TvName v, x)])
+-- inferPattern unify (Destructure cns ps ann)
+--   | Nothing <- ps = do
+--     pty <- lookupTy cns
+--     pure (Destructure (TvName cns) Nothing (ann, pty), pty, [])
+--   | Just p <- ps = do
+--     (tup, res, _) <- constructorTy <$> lookupTy cns
+--     (p', pt, pb) <- inferPattern unify p
+--     _ <- unify tup pt
+--     pure (Destructure (TvName cns) (Just p') (ann, res), res, pb)
+--   where constructorTy :: Type Typed -> (Type Typed, Type Typed, Type Typed)
+--         constructorTy t
+--           | TyArr tup res <- t = (tup, res, t)
+--           | otherwise = error (T.unpack (prettyPrint t))
+-- inferPattern unify (PRecord rows ann) = do
+--   rho <- freshTV
+--   (rowps, rowts, caps) <- unzip3 <$> for rows (\(var, pat) -> do
+--     (p', t, caps) <- inferPattern unify pat
+--     pure ((var, p'), (var, t), caps))
+--   pure (PRecord rowps (ann, TyRows rho rowts), TyRows rho rowts, concat caps)
+-- inferPattern unify (PType p t ann) = do
+--   (p', pt, vs) <- inferPattern unify p
+--   (t', _) <- resolveKind t
+--   _ <- unify pt t'
+--   case p' of
+--     Capture v _ -> pure (PType p' t' (ann, t'), t', [(v, t')])
+--     _ -> pure (PType p' t' (ann, t'), t', vs)
+-- inferPattern unify (PTuple elems ann)
+--   | [] <- elems = pure (PTuple [] (ann, tyUnit), tyUnit, [])
+--   | [x] <- elems = inferPattern unify x
+--   | otherwise = do
+--     (ps, t:ts, cps) <- unzip3 <$> traverse (inferPattern unify) elems
+--     pure (PTuple ps (ann, mkTT t ts), mkTT t ts, concat cps)
+
+
+inferPattern :: MonadInfer Typed m
+             => Pattern Resolved
+             -> m ( Pattern Typed -- the pattern
+                  , Type Typed -- type of what the pattern matches
+                  , [(Var Typed, Type Typed)] -- captures
+                  )
+inferPattern p = do
+  x <- freshTV
+  (p', binds) <- checkPattern p x
+  pure (p', x, binds)
+
+checkPattern :: MonadInfer Typed m
+             => Pattern Resolved
+             -> Type Typed
+             -> m ( Pattern Typed
+                  , [(Var Typed, Type Typed)]
+                  )
+checkPattern (Wildcard ann) ty = pure (Wildcard (ann, ty), [])
+checkPattern (Capture v ann) ty = pure (Capture (TvName v) (ann, ty), [(TvName v, ty)])
+checkPattern ex@(Destructure con ps ann) ty =
+  case ps of
+    Nothing -> do
+      pty <- lookupTy con
+      _ <- unify ex pty ty
+      pure (Destructure (TvName con) Nothing (ann, pty), [])
+    Just p -> do
+      ty <- lookupTy con
+      (c, d) <- decompose ex _TyArr ty
+      (ps', b) <- checkPattern p c
+      pure (Destructure (TvName con) (Just ps') (ann, ty), b)
+checkPattern pt@(PRecord rows ann) ty = do
+  rho <- freshTV
+  (rowps, rowts, caps) <- unzip3 <$> for rows (\(var, pat) -> do
+    (p', t, caps) <- inferPattern pat
+    pure ((var, p'), (var, t), caps))
+  _ <- unify pt ty (TyRows rho rowts)
+  pure (PRecord rowps (ann, TyRows rho rowts), concat caps)
+checkPattern pt@(PTuple elems ann) ty =
+  let go [x] t = (:[]) <$> checkPattern x t
+      go (x:xs) t = do
+        (left, right) <- decompose pt _TyTuple t
+        (:) <$> checkPattern x left <*> go xs right
+    in case elems of
+      [] -> do
+        _ <- unify pt ty tyUnit
+        pure (PTuple [] (ann, tyUnit), [])
+      [x] -> checkPattern x ty
+      xs -> do
+        (ps, concat -> binds) <- unzip <$> go xs ty
+        pure (PTuple ps (ann, ty), binds)
+checkPattern pt@(PType p t ann) ty = do
+  (p', it, binds) <- inferPattern p
+  (nt, _) <- resolveKind t
+  _ <- subsumes pt it nt
+  _ <- unify pt nt ty
+  pure (PType p' nt (ann, ty), binds)
+


### PR DESCRIPTION
Move to a pseudo-bidirectional type system algorithm, similar to the
one described for Damas-Milner inference in [0]. This isn't sound at
all, yet, particularly because of fiddlyness around the subsumption
check.b

We reuse most of the infrastructure, but the core judgement is
`Γ ⊢ x <= t` instead of `Γ ⊢ x => t` (i.e. checking instead of
synthesis).

You can recover inference from checking in a unification-based
system (like ours) like this:

```
infer e = do
  x <- fresh
  check e x
  pure (e, x)
```

I've moved over both expression and pattern type inference (the two which used to suck the most) to the new bidirectional system, but kinds are pretty much the same.
