### PR TITLE
Irrefutable Record Pattern Lowering

### DIFF
--- a/src/Backend/Compile.hs
+++ b/src/Backend/Compile.hs
@@ -96,6 +96,7 @@ compileExpr (CotRef v _) = LuaRef (lowerName v)
 compileExpr (CotLam Small (v, _) e) = LuaFunction [lowerName v] (compileStmt (Just LuaReturn) e)
 compileExpr (CotLam Big _ e) = compileExpr e
 compileExpr (CotTyApp f _) = compileExpr f
+compileExpr (CotAccess e k) = LuaRef (LuaIndex (compileExpr e) (LuaString k))
 
 compileExpr (CotLit (ColInt x))   = LuaNumber (fromInteger x)
 compileExpr (CotLit (ColStr str)) = LuaString str
@@ -117,6 +118,7 @@ global x = LuaRef (LuaIndex (LuaRef (LuaName "_G")) (LuaString (T.pack x)))
 
 compileStmt :: Returner -> CoTerm -> [LuaStmt]
 compileStmt r e@CotRef{} = pureReturn r $ compileExpr e
+compileStmt r e@CotAccess{} = pureReturn r $ compileExpr e
 compileStmt r e@CotLam{} = pureReturn r $ compileExpr e
 compileStmt r e@CotLit{} = pureReturn r $ compileExpr e
 compileStmt r (CotLet k c) = compileLet (unzip3 k) ++ compileStmt r c

--- a/src/Backend/Compile.hs
+++ b/src/Backend/Compile.hs
@@ -198,8 +198,6 @@ patternTest :: CoPattern -> LuaExpr ->  LuaExpr
 patternTest (CopCapture _ _) _   = LuaTrue
 patternTest (CopLit ColRecNil) _ = LuaTrue
 patternTest (CopLit l)     vr    = LuaBinOp (compileExpr (CotLit l)) "==" vr
-patternTest (CopExtend p rs) vr  = foldAnd (patternTest p vr : map test rs) where
-  test (var', pat) = patternTest pat (LuaRef (LuaIndex vr (LuaString var')))
 patternTest (CopConstr con) vr   = foldAnd [tag con vr]
 patternTest (CopDestr con p) vr  = foldAnd [tag con vr, patternTest p (LuaRef (LuaIndex vr (LuaNumber 2)))]
 
@@ -211,8 +209,6 @@ patternBindings (CopLit _) _        = []
 patternBindings (CopCapture n _) v  = [(lowerName n, v)]
 patternBindings (CopConstr _) _     = []
 patternBindings (CopDestr _ p) vr   = patternBindings p (LuaRef (LuaIndex vr (LuaNumber 2)))
-patternBindings (CopExtend p rs) vr = patternBindings p vr ++ concatMap (index vr) rs where
-  index vr (var', pat) = patternBindings pat (LuaRef (LuaIndex vr (LuaString var')))
 
 compileMatch :: Returner -> CoTerm -> [(CoPattern, CoType, CoTerm)] -> Gen Int [LuaStmt]
 compileMatch r ex ps =

--- a/src/Core/Core.hs
+++ b/src/Core/Core.hs
@@ -68,9 +68,9 @@ data CoStmt
 instance Pretty CoTerm where
   pprint (CotRef v _) = pprint v
   pprint (CotLam Big (v, t) c)
-    = opClr "Λ" <+> (v <+> opClr " : " <+> t) <+> opClr ". " <+> c
+    = opClr "Λ" <+> parens (v <+> opClr " : " <+> t) <+> opClr ". " <+> c
   pprint (CotLam Small (v, t) c)
-    = opClr "λ" <+> (v <+> opClr " : " <+> t) <+> opClr ". " <+> c
+    = opClr "λ" <+> parens (v <+> opClr " : " <+> t) <+> opClr ". " <+> c
   pprint (CotApp f x)
     | CotLam{} <- f = parens f <+> " " <+> parens x
     | CotLet{} <- f = parens f <+> " " <+> x

--- a/src/Core/Core.hs
+++ b/src/Core/Core.hs
@@ -90,6 +90,7 @@ instance Pretty CoTerm where
         <+> t
         <+> opClr " = "
         <+> v)
+  pprint (CotAccess e k) = parens (pprint e) <+> opClr "." <+> k
 
 pprLet :: [(Var Resolved, CoType, CoTerm)] -> PrettyP
 pprLet xs = interleave (opClr "; ") (map one xs) where
@@ -160,6 +161,7 @@ freeIn (CotLit _) = mempty
 freeIn (CotExtend c rs) = freeIn c <> foldMap (freeIn . thd3) rs
 freeIn (CotTyApp f _) = freeIn f
 freeIn (CotBegin xs x) = foldMap freeIn xs <> freeIn x
+freeIn (CotAccess e _) = freeIn e
 
 isError :: CoTerm -> Bool
 isError (CotApp (CotTyApp (CotRef (TgInternal n) _) _) _) = n == pack "error"

--- a/src/Core/Core.hs
+++ b/src/Core/Core.hs
@@ -101,7 +101,7 @@ pprCases xs = interleave (opClr "; ") (map one xs) where
   one (a, b, c) = a <+> opClr " : " <+> b <+> opClr " -> " <+> c
 
 instance Pretty CoPattern where
-  pprint (CopCapture v t) = parens (v <+> opClr " : " <+> t)
+  pprint (CopCapture v _) = pprint v
   pprint (CopConstr v) = pprint v
   pprint (CopDestr v p) = parens (v <+> " " <+> p)
   pprint (CopLit l) = pprint l

--- a/src/Core/Core.hs
+++ b/src/Core/Core.hs
@@ -90,7 +90,9 @@ instance Pretty CoTerm where
         <+> t
         <+> opClr " = "
         <+> v)
-  pprint (CotAccess e k) = parens (pprint e) <+> opClr "." <+> k
+  pprint (CotAccess e k)
+    | CotRef{} <- e = e <+> opClr "." <+> k
+    | otherwise = parens e <+> opClr "." <+> k
 
 pprLet :: [(Var Resolved, CoType, CoTerm)] -> PrettyP
 pprLet xs = interleave newline (map one xs) where

--- a/src/Core/Core.hs
+++ b/src/Core/Core.hs
@@ -79,10 +79,10 @@ instance Pretty CoTerm where
     | CotMatch{} <- x = f <+> " " <+> parens x
     | otherwise = f <+> " " <+> x
   pprint (CotLet xs e) =
-    kwClr "let " <+> braces (pprLet xs) <+> kwClr " in " <+> e
+    kwClr "let " <+> block 2 (braces (newline *> pprLet xs)) <+> kwClr " in " <+> e
   pprint (CotBegin xs e) = kwClr "begin " <+> interleave (opClr "; ") (xs ++ [e]) <+> kwClr " end"
   pprint (CotLit l) = pprint l
-  pprint (CotMatch e ps) = kwClr "match " <+> e <+> " " <+> braces (pprCases ps)
+  pprint (CotMatch e ps) = kwClr "match " <+> e <+> " " <+> block 2 (braces (newline *> pprCases ps))
   pprint (CotTyApp f t) = f <+> opClr " @" <+> t
   pprint (CotExtend x rs) = braces $ x <+> opClr " | " <+> prettyRows rs where
     prettyRows = interleave ", " . map (\(x, t, v) ->
@@ -93,11 +93,13 @@ instance Pretty CoTerm where
   pprint (CotAccess e k) = parens (pprint e) <+> opClr "." <+> k
 
 pprLet :: [(Var Resolved, CoType, CoTerm)] -> PrettyP
-pprLet xs = interleave (opClr "; ") (map one xs) where
-  one (a, b, c) = a <+> opClr " : " <+> b <+> opClr " = " <+> c
+pprLet xs = interleave newline (map one xs) where
+  one (a, b, c) = do
+    a <+> opClr " : " <+> b <+> opClr " = "
+    block 2 (newline <* pprint c)
 
 pprCases :: [(CoPattern, CoType, CoTerm)] -> PrettyP
-pprCases xs = interleave (opClr "; ") (map one xs) where
+pprCases xs = interleave newline (map one xs) where
   one (a, b, c) = a <+> opClr " : " <+> b <+> opClr " -> " <+> c
 
 instance Pretty CoPattern where

--- a/src/Core/Optimise.hs
+++ b/src/Core/Optimise.hs
@@ -42,6 +42,7 @@ mapTerm1M f t = case t of
   CotBegin es e -> CotBegin <$> traverse f es <*> f e
   CotExtend t rs -> CotExtend <$> f t <*> traverse (third3A f) rs
   CotTyApp e t -> CotTyApp <$> f e <*> pure t
+  CotAccess e k -> CotAccess <$> f e <*> pure k
 
 -- Apply a function to all descendants in the provided expr.
 mapTermM :: Monad m => (CoTerm -> m CoTerm) -> CoTerm -> m CoTerm

--- a/src/Core/Optimise/Fold.hs
+++ b/src/Core/Optimise/Fold.hs
@@ -94,6 +94,7 @@ dropUselessLet = pass' go where
   pure CotLit{} = True
   pure CotApp{} = False
   pure (CotTyApp f _) = pure f
+  pure (CotAccess f _) = pure f
   pure (CotLet vs e) = pure e && all (pure . thd3) vs
   pure (CotBegin xs e) = all pure xs && pure e
   pure (CotMatch e bs) = pure e && all (pure . thd3) bs

--- a/src/Core/Optimise/Inline.hs
+++ b/src/Core/Optimise/Inline.hs
@@ -66,7 +66,8 @@ score CotLit{} = pure 1
 score (CotBegin es e) = do
   es' <- sum <$> traverse score es
   (+) es' <$> score e
-score (CotTyApp t _) = (+ 1) <$> score t
+score (CotTyApp t _) = (subtract 1) <$> score t
+score (CotAccess e _) = (+ 5) <$> score e
 
 -- go :: CoTerm -> Trans Int
 -- go (CotRef v _) = do

--- a/src/Core/Optimise/Match.hs
+++ b/src/Core/Optimise/Match.hs
@@ -4,11 +4,8 @@ module Core.Optimise.Match
 
 import qualified Data.Map.Strict as Map
 import Data.Triple
-import Data.Monoid
 import Data.Maybe
 import Data.List
-
-import Control.Monad
 
 import Syntax (Var, Resolved)
 import Core.Optimise
@@ -65,13 +62,6 @@ matchKnownConstr = pass go where
   match (CopDestr v p) (CotApp (CotRef v' _) x)
     | v == v' = match p x
     | otherwise = Nothing
-  match (CopExtend p xs) (CotExtend e ys) = match p e <> rows where
-    xs' = sortOn fst xs
-    ys' = sortOn fst (map (\(x, _, y) -> (x, y)) ys)
-    rows = concat <$> zipWithM mr xs' ys'
-    mr (t, p) (t', e)
-      | t == t' = match p e
-      | otherwise = Nothing
   match (CopLit l) (CotLit l')
     | l == l' = Just []
     | otherwise = Nothing

--- a/src/Types/Infer.hs
+++ b/src/Types/Infer.hs
@@ -206,11 +206,11 @@ inferLetTy closeOver ks ((va, ve, vann):xs) = extendMany ks $ do
   cur <- gen
   (x, vt) <- case solve cur mempty c of
     Left e -> throwError e
-    Right x -> pure (x, closeOver (apply x ty))
-  let r (a, t) = (a, apply x t)
+    Right x -> pure (x, closeOver (normType (apply x ty)))
+  let r (a, t) = (a, normType (apply x t))
       ex = applyInExpr x (raiseE id r ve')
   consFst (TvName va, ex, (vann, vt)) $
-    inferLetTy closeOver (updateAlist (TvName va) vt ks) xs
+    inferLetTy closeOver (updateAlist (TvName va) (normType vt) ks) xs
 
 applyInExpr :: Map.Map (Var Typed) (Type Typed) -> Expr Typed -> Expr Typed
 applyInExpr ss = everywhere (mkT go) where

--- a/src/Types/Unify.hs
+++ b/src/Types/Unify.hs
@@ -58,7 +58,7 @@ unify (TyRows rho arow) (TyRows sigma brow)
        if length overlaps >= length new
           then error ("overlaps " ++ show (length overlaps) ++ " new " ++ show (length new))
           else pure ()
-unify ta@(TyExactRows arow) tb@(TyRows rho brow)
+unify ta@(TyExactRows arow) (TyRows rho brow)
   | overlaps <- overlap arow brow
   = case overlaps of
       [] -> unify rho ta

--- a/src/Types/Wellformed.hs
+++ b/src/Types/Wellformed.hs
@@ -2,12 +2,14 @@
 module Types.Wellformed (wellformed, arity, normType) where
 
 import Control.Monad.Except
-
 import Control.Monad.Infer
-import Syntax
+import Control.Arrow
 
+import Data.Function
 import Data.Foldable
-import Data.List (union)
+import Data.List (union, unionBy)
+
+import Syntax
 
 import Pretty(Pretty)
 
@@ -36,6 +38,10 @@ arity _ = 0
 normType :: Eq (Var p) => Type p -> Type p
 normType (TyForall vs (TyForall vs' tp)) = TyForall (vs `union` vs') (normType tp)
 normType (TyForall [] tp) = normType tp
+normType (TyRows x rs')
+  | TyRows rho rs <- normType x = normType (TyRows rho (normRows (unionBy ((==) `on` fst) rs rs')))
+  | TyExactRows rs <- normType x = normType (TyExactRows (normRows (unionBy ((==) `on` fst) rs rs')))
+    where normRows = map (second normType)
 normType x = x
 
 {-


### PR DESCRIPTION
 
Record patterns are lowered into a series of nested pattern matches on
record accessors corresponding to the original.

```ocaml   
match foo with
| { x = k, y = l } -> ...
```    
=> 
```ocaml
match foo.x with
| k -> match foo.y with
  | l -> ...
```

This means that the optimiser has more stuff do to but the Core grammar is less crap.