### PR TITLE
Use type-directed lowering

### DIFF
--- a/src/Core/Lower.hs
+++ b/src/Core/Lower.hs
@@ -133,7 +133,7 @@ lowerType tt = case tt of
     for vs $ \(label, tp) -> (,) label <$> lowerType tp
   TyVar (TvName v) -> pure (CotyVar v)
   TyCon (TvName v) -> pure (CotyCon v)
-  TySkol (Skolem (TvName v) _ _) -> pure (CotyCon v)
+  TySkol (Skolem _ (TvName v) _) -> pure (CotyVar v)
 
 tup2Rec :: MonadLower m => Int -> Type Typed -> m [(T.Text, CoType)]
 tup2Rec k (TyTuple a b) = do

--- a/src/Core/Lower.hs
+++ b/src/Core/Lower.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE FlexibleContexts, ConstraintKinds, OverloadedStrings #-}
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LambdaCase, TupleSections #-}
 module Core.Lower
   ( lowerExpr
   , lowerType
@@ -104,7 +104,7 @@ lowerAnyway (Record xs _) = case xs of
     pure (CotExtend (CotLit ColRecNil) xs')
 lowerAnyway (RecordExt e xs _) = do
   xs' <- for xs $ \(label, ex) ->
-    (,,) <$> pure label <*> lowerType (getType ex) <*> lowerExpr ex
+    (label,,) <$> lowerType (getType ex) <*> lowerExpr ex
   CotExtend <$> lowerExpr e <*> pure xs'
 lowerAnyway (Literal l _) = pure . CotLit $ case l of
   LiInt i -> ColInt i

--- a/src/Core/Optimise/Inline.hs
+++ b/src/Core/Optimise/Inline.hs
@@ -42,8 +42,6 @@ betaReduce = pass go where
       pure . CotLet [(var', tp, ex)] .  substitute (Map.singleton var ref) $ body
     CotTyApp (CotLam Big (var, _) body) tp ->
       pure $ substituteInTys (Map.singleton var tp) body
-    CotTyApp body@CotLam{} _ -> pure body -- TODO: This really shouldn't happen but it does
-    -- We need it to generate better code in the rank-N case
     _ -> pure term
 
 score :: CoTerm -> Trans Int


### PR DESCRIPTION
Instead of guessing when things should be quantified, we can use the
fact that we statically know the types of everything to figure out
precisely when things should be quantified.

This does that.