### PR TITLE
Add tuple sections

### DIFF
--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -94,6 +94,7 @@ data Expr p
 
   -- Tuple (see note [1])
   | Tuple [Expr p] (Ann p)
+  | TupleSection [Maybe (Expr p)] (Ann p)
 
   -- Explicit type application
   | TypeApp (Expr p) (Type p) (Ann p)

--- a/src/Syntax/Pretty.hs
+++ b/src/Syntax/Pretty.hs
@@ -57,6 +57,7 @@ instance (Pretty (Var p)) => Pretty (Expr p) where
   pretty (AccessSection k _) = parens $ dot <> text k
 
   pretty (Tuple es _) = parens (hsep (punctuate comma (map pretty es)))
+  pretty (TupleSection es _) = parens (hsep (punctuate comma (map (maybe (string "") pretty) es)))
   pretty (TypeApp f x _) = parenFun f <+> soperator (char '@') <> pretty x
 
 prettyMatches :: (Pretty (Var p)) => [(Pattern p, Expr p)] -> [Doc]

--- a/src/Syntax/Resolve.hs
+++ b/src/Syntax/Resolve.hs
@@ -183,6 +183,7 @@ reExpr (BothSection o a) = BothSection <$> reExpr o <*> pure a
 reExpr (AccessSection t a) = pure (AccessSection t a)
 
 reExpr (Tuple es a) = Tuple <$> traverse reExpr es <*> pure a
+reExpr (TupleSection es a) = TupleSection <$> traverse (traverse reExpr) es <*> pure a
 reExpr (TypeApp f x a) = TypeApp <$> reExpr f <*> reType x <*> pure a
 
 reType :: MonadResolve m => Type Parsed -> m (Type Resolved)


### PR DESCRIPTION
This adds several extensions to the syntax of tuples:

 - Any part of a tuple is optional, allowing for `(1, 2)`, `(1,)`, `(,)`, etc...
 - Operator sections can be part of a tuple, so `(+1,1+,.access)` is now valid.