### PR TITLE
Feature: Coercions

### DIFF
--- a/src/Backend/Compile.hs
+++ b/src/Backend/Compile.hs
@@ -144,6 +144,7 @@ compileTerm (App f e) = do
     (fl', _) -> LuaCall fl' [e']
 
 compileTerm (TyApp f _) = compileAtom f
+compileTerm (Cast f _) = compileAtom f
 
 compileTerm (Extend (Lit RecNil) fs) = do
   fs' <- foldrM compileRow [] fs

--- a/src/Core/Core.hs
+++ b/src/Core/Core.hs
@@ -27,6 +27,7 @@ data Term a
   | Extend (Atom a) [(Text, Type a, Atom a)]
 
   | TyApp (Atom a) (Type a) -- removes a Λ
+  | Cast (Atom a) (Coercion a)
   deriving (Eq, Show, Ord, Data, Typeable, Functor)
 
 data Pattern a
@@ -36,6 +37,12 @@ data Pattern a
   | PatExtend (Pattern a) [(Text, Pattern a)]
 
   | PatLit Literal
+  deriving (Eq, Show, Ord, Data, Typeable, Functor)
+
+data Coercion a
+  = SameRepr (Type a) (Type a)
+  | Domain (Coercion a)
+  | Codomain (Coercion a)
   deriving (Eq, Show, Ord, Data, Typeable, Functor)
 
 data Literal
@@ -84,6 +91,12 @@ instance Pretty a => Pretty (Term a) where
   pretty (Match e ps) = keyword "match" <+> pretty e <+> pprCases ps
   pretty (Extend x rs) = braces $ pretty x <+> pipe <+> prettyRows rs where
     prettyRows = hsep . punctuate comma . map (\(x, t, v) -> text x <+> colon <+> pretty t <+> equals <+> pretty v)
+  pretty (Cast a phi) = parens $ pretty a <+> soperator (string "|>") <+> pretty phi
+
+instance Pretty a => Pretty (Coercion a) where
+  pretty (SameRepr a b) = pretty a <+> soperator (char '~') <+> pretty b
+  pretty (Domain f) = keyword "dom" <+> pretty f
+  pretty (Codomain f) = keyword "cod" <+> pretty f
 
 pprLet :: Pretty a => [(a, Type a, Term a)] -> Doc
 pprLet = braces' . vsep . map (indent 2) . punctuate semi . map pprLet1
@@ -163,6 +176,7 @@ freeIn (Match e bs) = freeInAtom e <> foldMap freeInBranch bs where
   freeInBranch (b, _, e) = VarSet.difference (freeIn e) (patternVars b)
 freeIn (Extend c rs) = freeInAtom c <> foldMap (freeInAtom . thd3) rs
 freeIn (TyApp f _) = freeInAtom f
+freeIn (Cast f _) = freeInAtom f
 
 occursInAtom :: IsVar a => a -> Atom a -> Bool
 occursInAtom v (Ref v' _) = toVar v == toVar v'
@@ -173,6 +187,7 @@ occursInTerm :: IsVar a => a -> Term a -> Bool
 occursInTerm v (Atom a) = occursInAtom v a
 occursInTerm v (App f x) = occursInAtom v f || occursInAtom v x
 occursInTerm v (TyApp f _) = occursInAtom v f
+occursInTerm v (Cast f _) = occursInAtom v f
 occursInTerm v (Let vs e) = any (occursInTerm v . thd3) vs || occursInTerm v e
 occursInTerm v (Match e bs) = occursInAtom v e || any (occursInTerm v . thd3) bs
 occursInTerm v (Extend e fs) = occursInAtom v e || any (occursInAtom v . thd3) fs

--- a/src/Core/Occurrence.hs
+++ b/src/Core/Occurrence.hs
@@ -87,6 +87,7 @@ tagOccTerm (Match e bs) = Match (tagOccAtom e) (map tagArm bs) where
   tagArm (p, t, e) = (fmap (flip depends (countUsages e)) p, convert t, tagOccTerm e)
 tagOccTerm (Extend l rs) = Extend (tagOccAtom l) (map (\(r, t, e) -> (r, convert t, tagOccAtom e)) rs)
 tagOccTerm (TyApp f x) = TyApp (tagOccAtom f) (convert x)
+tagOccTerm (Cast f x) = Cast (tagOccAtom f) (convert x)
 
 depends :: IsVar a => a -> OccursMap -> OccursVar a
 depends v ss = OccursVar v (fromMaybe 0 (toVar v `Map.lookup` ss))
@@ -111,6 +112,7 @@ countUsages = term where
   term (Match e vs) = atom e # foldr (#) mempty (map (term . thd3) vs)
   term (Extend e rs) = atom e # foldr (#) mempty (map (atom . thd3) rs)
   term (TyApp f _) = atom f
+  term (Cast f _) = atom f
 
   atom (Ref v _) = Map.singleton (toVar v) 1
   atom (Lam _ _ b) = term b

--- a/src/Core/Optimise.hs
+++ b/src/Core/Optimise.hs
@@ -1,18 +1,22 @@
+{-# LANGUAGE FlexibleContexts, TupleSections, PartialTypeSignatures #-}
 module Core.Optimise
   ( substitute, substituteInTys, substituteInCo
   , module Core.Core
   , Var(..)
-  , fresh
+  , refresh, fresh, freshFrom
   ) where
 
 import qualified Data.Map.Strict as Map
-
+import qualified Data.VarMap as VarMap
 import Data.VarSet (IsVar(..))
 
-import Control.Monad.Infer (fresh)
-
+import Control.Monad.Infer (fresh, freshFrom)
 import Control.Arrow (second)
+import Control.Monad.Gen
+
+import Data.Foldable
 import Data.Triple
+import Data.Maybe
 
 import Core.Core
 import Syntax (Var(..))
@@ -74,3 +78,63 @@ substituteInCo m = coercion where
   gotype (RowsTy v rs) = RowsTy (gotype v) (map (second gotype) rs)
   gotype (ExactRowsTy rs) = ExactRowsTy (map (second gotype) rs)
   gotype StarTy = StarTy
+
+
+refresh :: (MonadGen Int m, IsVar a) => Term a -> m (Term a)
+refresh = refreshTerm mempty where
+  refreshAtom :: (MonadGen Int m, IsVar a) => VarMap.Map a -> Atom a -> m (Atom a)
+  refreshAtom s a@(Ref v ty) =
+    case VarMap.lookup (toVar v) s of
+      Just x -> pure (Ref x ty)
+      Nothing -> pure a
+  refreshAtom _ a@Lit{} = pure a
+  refreshAtom s (Lam size (v, ty) b) = do
+    let TgName name _ = toVar v
+    v' <- fromVar <$> freshFrom name
+    Lam size (v', ty) <$> refreshTerm (VarMap.insert (toVar v) v' s) b
+
+
+  refreshTerm :: (MonadGen Int m, IsVar a) => VarMap.Map a -> Term a -> m (Term a)
+  refreshTerm s (Atom a) = Atom <$> refreshAtom s a
+  refreshTerm s (App f x) = App <$> refreshAtom s f <*> refreshAtom s x
+  refreshTerm s (TyApp f ty) = TyApp <$> refreshAtom s f <*> pure (refreshType s ty)
+  refreshTerm s (Let vs b) = do
+    s' <- foldrM (\(v, _, _) m -> do
+                     let TgName name _ = toVar v
+                     v' <- fromVar <$> freshFrom name
+                     pure (VarMap.insert (toVar v) v' m)) s vs
+    vs' <- traverse (\(v, ty, e) -> (fromJust (VarMap.lookup (toVar v) s'), ty,) <$> refreshTerm s' e) vs
+    Let vs' <$> refreshTerm s' b
+  refreshTerm s (Match e branches) = Match <$> refreshAtom s e
+                                            <*> traverse refreshBranch branches where
+    refreshBranch (test, ty, branch) = do
+      s' <- foldrM (\v m -> do
+                       let TgName name _ = toVar v
+                       v' <- fromVar <$> freshFrom name
+                       pure (VarMap.insert (toVar v) v' m)) s (patternVarsA test `asTypeOf` [])
+      (refreshPattern s' test, refreshType s' ty,) <$> refreshTerm s' branch
+  refreshTerm s (Extend e bs) = Extend <$> refreshAtom s e <*> traverse (third3A (refreshAtom s)) bs
+  refreshTerm s (Cast e c) = Cast <$> refreshAtom s e <*> pure (refreshCoercion s c)
+
+  refreshPattern :: IsVar a => VarMap.Map a -> Pattern a -> Pattern a
+  refreshPattern s (Capture v ty) = Capture (fromJust (VarMap.lookup (toVar v) s)) (refreshType s ty)
+  refreshPattern _ p@Constr{} = p
+  refreshPattern s (Destr c p) = Destr c (refreshPattern s p)
+  refreshPattern s (PatExtend p fs) = PatExtend (refreshPattern s p) (map (second (refreshPattern s)) fs)
+  refreshPattern _ p@PatLit{} = p
+
+  refreshType :: IsVar a => VarMap.Map a -> Type a -> Type a
+  refreshType s x@(VarTy v) = maybe x VarTy (VarMap.lookup (toVar v) s)
+  refreshType _ x@ConTy{} = x
+  refreshType s (ForallTy v t) = ForallTy v (refreshType s t)
+  refreshType s (ArrTy a b) = ArrTy (refreshType s a) (refreshType s b)
+  refreshType s (AppTy f x) = AppTy (refreshType s f) (refreshType s x)
+  refreshType s (RowsTy v rs) = RowsTy (refreshType s v) (map (second (refreshType s)) rs)
+  refreshType s (ExactRowsTy rs) = ExactRowsTy (map (second (refreshType s)) rs)
+  refreshType _ StarTy = StarTy
+
+  refreshCoercion :: IsVar a => VarMap.Map a -> Coercion a -> Coercion a
+  refreshCoercion s (SameRepr t t') = SameRepr (refreshType s t) (refreshType s t')
+  refreshCoercion s (Domain c) = Domain (refreshCoercion s c)
+  refreshCoercion s (Codomain c) = Codomain (refreshCoercion s c)
+  refreshCoercion s (Symmetry c) = Symmetry (refreshCoercion s c)

--- a/src/Core/Optimise.hs
+++ b/src/Core/Optimise.hs
@@ -25,6 +25,7 @@ substitute m = term where
   term (Match x vs) = Match (atom x) (map (third3 term) vs)
   term (Extend e rs) = Extend (atom e) (map (third3 atom) rs)
   term (TyApp f t) = TyApp (atom f) t
+  term (Cast f t) = Cast (atom f) t
 
   atom x@(Ref v _) = Map.findWithDefault x v m
   atom (Lam s v b) = Lam s v (term b)
@@ -38,6 +39,11 @@ substituteInTys m = term where
   term (Match x vs) = Match (atom x) (map (\(v, t, e) -> (v, gotype t, term e)) vs)
   term (Extend e rs) = Extend (atom e) (map (third3 atom) rs)
   term (TyApp f t) = TyApp (atom f) (gotype t)
+  term (Cast f t) = Cast (atom f) (coercion t)
+
+  coercion (SameRepr t t') = SameRepr (gotype t) (gotype t')
+  coercion (Domain c) = Domain (coercion c)
+  coercion (Codomain c) = Codomain (coercion c)
 
   atom (Ref v t) = Ref v (gotype t)
   atom (Lam s (v, t) b) = Lam s (v, gotype t) (term b)

--- a/src/Core/Optimise.hs
+++ b/src/Core/Optimise.hs
@@ -44,6 +44,7 @@ substituteInTys m = term where
   coercion (SameRepr t t') = SameRepr (gotype t) (gotype t')
   coercion (Domain c) = Domain (coercion c)
   coercion (Codomain c) = Codomain (coercion c)
+  coercion (Symmetry c) = Symmetry (coercion c)
 
   atom (Ref v t) = Ref v (gotype t)
   atom (Lam s (v, t) b) = Lam s (v, gotype t) (term b)
@@ -63,6 +64,7 @@ substituteInCo m = coercion where
   coercion (SameRepr t t') = SameRepr (gotype t) (gotype t')
   coercion (Domain c) = Domain (coercion c)
   coercion (Codomain c) = Codomain (coercion c)
+  coercion (Symmetry c) = Symmetry (coercion c)
 
   gotype x@(VarTy v) = Map.findWithDefault x v m
   gotype x@ConTy{} = x

--- a/src/Core/Optimise/DeadCode.hs
+++ b/src/Core/Optimise/DeadCode.hs
@@ -56,6 +56,7 @@ deadCodePass = snd . freeS (DeadScope mempty) Nothing where
   freeT s (Atom a) = Atom <$> freeA s a
   freeT s (App f a) = App <$> freeA s f <*> freeA s a
   freeT s (TyApp f t) = TyApp <$> freeA s f <*> pure t
+  freeT s (Cast f t) = Cast <$> freeA s f <*> pure t
   freeT s (Extend t rs) = Extend <$> freeA s t <*> traverse (third3A (freeA s)) rs
 
   freeT s (Let vs b) =
@@ -99,6 +100,7 @@ deadCodePass = snd . freeS (DeadScope mempty) Nothing where
   isPure _ Atom{}   = True
   isPure _ Extend{} = True
   isPure _ TyApp{}  = True
+  isPure _ Cast{}  = True
   isPure s (Let vs e) = isPure s e && all (isPure s . thd3) vs
   isPure s (Match _ bs) = all (isPure s . thd3) bs
   isPure s (App f _) = atomArity s f > 0

--- a/src/Core/Optimise/Inline.hs
+++ b/src/Core/Optimise/Inline.hs
@@ -1,7 +1,9 @@
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ScopedTypeVariables, FlexibleContexts #-}
 module Core.Optimise.Inline
   ( inlineVariablePass
   ) where
+
+import Control.Monad.Gen
 
 import qualified Data.VarMap as VarMap
 import qualified Data.VarSet as VarSet
@@ -15,53 +17,52 @@ limit :: Int
 limit = 500
 
 data InlineScope a = InlineScope { scores :: VarMap.Map (Atom a, Int)
-                                 -- , vars :: VarMap.Map (Term a)
                                  , cons :: VarSet.Set }
 
-inlineVariablePass :: IsVar a => [Stmt a] -> [Stmt a]
+inlineVariablePass :: (MonadGen Int m, IsVar a) => [Stmt a] -> m [Stmt a]
 inlineVariablePass = transS (InlineScope mempty mempty) where
-  transS _ [] = []
-  transS s (x@Foreign{}:xs) = x:transS s xs
-  transS s (StmtLet vars:xs) =
-    let vars' = map (third3 (transT s)) vars
-        xs' = transS (extendVars vars' s) xs
-    in StmtLet vars':xs'
+  transS _ [] = pure []
+  transS s (x@Foreign{}:xs) = (x:) <$> transS s xs
+  transS s (StmtLet vars:xs) = do
+    vars' <- traverse (third3A (transT s)) vars
+    xs' <- transS (extendVars vars' s) xs
+    pure (StmtLet vars':xs')
   transS s (x@(Type _ cases):xs) =
     let s' = s { cons = VarSet.fromList (map (toVar . fst) cases) `VarSet.union` cons s }
-    in x:transS s' xs
+    in (x:) <$> transS s' xs
 
-  transA _ t@Ref{} = t
-  transA _ t@Lit{} = t
-  transA s (Lam t v b) = Lam t v (transT s b)
+  transA _ t@Ref{} = pure t
+  transA _ t@Lit{} = pure t
+  transA s (Lam t v b) = Lam t v <$> transT s b
 
-  transT :: IsVar a => InlineScope a -> Term a -> Term a
-  transT s (Atom a) = Atom (transA s a)
-  transT s (App f a) =
-    let f' = transA s f
-        a' = transA s a
-     in case f' of
-         Ref r _
-           | Just (Lam Small (v, t) b, score) <- VarMap.lookup (toVar r) (scores s)
-           , score <= limit -> Let [(v, t, Atom a')] b
-         Lam Small (v, t) b -> Let [(v, t, Atom a')] b
-         _ -> App f' a'
-  transT s (Cast f t) = Cast (transA s f) t
-  transT s (TyApp f t) =
-    case transA s f of
+  transT :: (MonadGen Int m, IsVar a) => InlineScope a -> Term a -> m (Term a)
+  transT s (Atom a) = Atom <$> transA s a
+  transT s (App f a) = do
+    f' <- transA s f
+    a' <- transA s a
+    case f' of
+      Ref r _
+        | Just (Lam Small (v, t) b, score) <- VarMap.lookup (toVar r) (scores s)
+        , score <= limit -> refresh$ Let [(v, t, Atom a')] b
+      Lam Small (v, t) b -> pure $ Let [(v, t, Atom a')] b
+      _ -> pure (App f' a')
+  transT s (Cast f t) = flip Cast t <$> transA s f
+  transT s (TyApp f t) = do
+    f' <- transA s f
+    case f' of
       Ref r _
         | Just (Lam Big (v, _) b, score) <- VarMap.lookup (toVar r) (scores s)
-        , score <= limit -> substituteInTys (Map.singleton v t) b
-      Lam Big (v, _) b -> substituteInTys (Map.singleton v t) b
-      f' -> TyApp f' t
-  transT s (Extend t rs) = Extend (transA s t) (map (third3 (transA s)) rs)
-  transT s (Let vars body) =
-    let vars' = map (third3 (transT s)) vars
-        body' = transT (extendVars vars' s) body
-    in Let vars' body'
-  transT s (Match test branches) =
-    let test' = transA s test
-        branches' = map (third3 (transT s)) branches
-    in Match test' branches'
+        , score <= limit -> refresh $ substituteInTys (Map.singleton v t) b
+      Lam Big (v, _) b -> pure $ substituteInTys (Map.singleton v t) b
+      f' -> pure $ TyApp f' t
+  transT s (Extend t rs) = Extend <$> transA s t
+                                  <*> traverse (third3A (transA s)) rs
+  transT s (Let vars body) = do
+    vars' <- traverse (third3A (transT s)) vars
+    body' <- transT (extendVars vars' s) body
+    pure (Let vars' body')
+  transT s (Match test branches) = Match <$> transA s test
+                                         <*> traverse (third3A (transT s)) branches
 
   extendVars vs s = s
     { scores = foldr (\(v, _, e) m ->
@@ -70,7 +71,6 @@ inlineVariablePass = transS (InlineScope mempty mempty) where
                             | isLambda a && not (occursInTerm v e)
                             -> VarMap.insert (toVar v) (a, scoreTerm s e) m
                           _ -> m) (scores s) vs
-    -- , vars = foldr (\(v, _, e) m -> VarMap.insert (toVar v) e m) (vars s) vs
     }
 
   isLambda (Lam Small _ _) = True

--- a/src/Core/Optimise/Inline.hs
+++ b/src/Core/Optimise/Inline.hs
@@ -45,6 +45,7 @@ inlineVariablePass = transS (InlineScope mempty mempty) where
            , score <= limit -> Let [(v, t, Atom a')] b
          Lam Small (v, t) b -> Let [(v, t, Atom a')] b
          _ -> App f' a'
+  transT s (Cast f t) = Cast (transA s f) t
   transT s (TyApp f t) =
     case transA s f of
       Ref r _
@@ -89,3 +90,4 @@ scoreTerm s (Let vs e) = sum (map (scoreTerm s . thd3) vs) + scoreTerm s e
 scoreTerm s (Match e bs) = scoreAtom s e + sum (map (scoreTerm s . thd3) bs)
 scoreTerm s (Extend e rs) = scoreAtom s e + sum (map (scoreAtom s . thd3) rs)
 scoreTerm s (TyApp t _) = scoreAtom s t
+scoreTerm s (Cast t _) = scoreAtom s t

--- a/src/Core/Optimise/Newtype.hs
+++ b/src/Core/Optimise/Newtype.hs
@@ -9,7 +9,6 @@ import Data.Triple
 
 import Core.Optimise
 import Core.Types
-import Core.Core
 
 killNewtypePass :: forall a. IsVar a => [Stmt a] -> Gen Int [Stmt a]
 killNewtypePass = go mempty where

--- a/src/Core/Optimise/Newtype.hs
+++ b/src/Core/Optimise/Newtype.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE ScopedTypeVariables, OverloadedStrings #-}
+module Core.Optimise.Newtype (killNewtypePass) where
+
+import Control.Monad.Infer (Gen, fresh)
+
+import qualified Data.VarMap as V
+import Data.VarSet (IsVar(..))
+import Data.Triple
+
+import Core.Core
+
+killNewtypePass :: forall a. IsVar a => [Stmt a] -> Gen Int [Stmt a]
+killNewtypePass = go mempty where
+  go :: V.Map (Coercion a) -> [Stmt a] -> Gen Int [Stmt a]
+  go m (Type n cs:xs) = case cs of
+    [(var, tp)] | Just nt <- isNewtype tp -> do
+      (con, phi) <- newtypeCo (var, tp) nt
+      (Type n [] :) . (con :) <$> go (V.insert (toVar var) phi m) xs
+    _ -> (Type n cs:) <$> go m xs
+  go m (x@Foreign{}:xs) = (x:) <$> go m xs
+  go m (StmtLet vs:xs) = do
+    vs' <- goBinding m vs
+    (StmtLet vs':) <$> go m xs
+  go _ [] = pure []
+
+isNewtype :: Type a -> Maybe (Type a, Type a)
+isNewtype (ForallTy _ t) = isNewtype t
+isNewtype (ArrTy x y) = Just (x, y)
+isNewtype _ = Nothing
+
+newtypeMatch :: IsVar a => V.Map (Coercion a) -> [(Pattern a, Type a, Term a)] -> Maybe (Coercion a, (Pattern a, Type a, Term a))
+newtypeMatch m (it@(Destr c _, _, _):xs)
+  | Just phi <- V.lookup (toVar c) m = pure (phi, it)
+  | otherwise = newtypeMatch m xs
+newtypeMatch m (_:xs) = newtypeMatch m xs
+newtypeMatch _ [] = Nothing
+
+newtypeCo :: IsVar a => (a, Type a) -> (Type a, Type a) -> Gen Int (Stmt a, Coercion a)
+newtypeCo (cn, tp) (dom, cod) = do
+  var <- fresh
+  let con = [(cn, tp, Atom (wrap tp (work phi)))]
+      wrap (ForallTy v t) e = Lam Big (v, StarTy) (Atom (wrap t e))
+      wrap _ e = e
+
+      phi = SameRepr dom cod
+
+      work c = Lam Small (fromVar var, dom) (Cast (Ref (fromVar var) dom) c)
+  pure (StmtLet con, phi)
+
+
+goBinding :: forall a. IsVar a => V.Map (Coercion a) -> [(a, Type a, Term a)] -> Gen Int [(a, Type a, Term a)]
+goBinding m vs = traverse (third3A (goTerm m)) vs where
+  goTerm :: V.Map (Coercion a) -> Term a -> Gen Int (Term a)
+  goTerm m (Atom x) = Atom <$> goAtom m x
+  goTerm m (App f x) = App <$> goAtom m f <*> goAtom m x
+  goTerm m (Let vs e) = Let <$> goBinding m vs <*> (goTerm m e)
+  goTerm m (Extend a as) = Extend <$> goAtom m a <*> traverse (third3A (goAtom m)) as
+  goTerm m (TyApp f t) = TyApp <$> goAtom m f <*> pure t
+  goTerm m (Cast f t) = Cast <$> goAtom m f <*> pure t
+  goTerm m (Match a x) = case newtypeMatch m x of
+    Just (phi, (Destr _ p, _, bd)) -> do
+      var <- fresh
+      let SameRepr _ castCodomain = phi
+      bd <- goTerm m (Match (Ref (fromVar var) castCodomain) [(p, castCodomain, bd)])
+      pure $ Let [(fromVar var, castCodomain, Cast a phi)] bd
+    _ -> Match <$> goAtom m a <*> traverse (third3A (goTerm m)) x
+
+  goAtom m (Lam s v e) = Lam s v <$> goTerm m e
+  goAtom _ x = pure x

--- a/src/Core/Optimise/Reduce.hs
+++ b/src/Core/Optimise/Reduce.hs
@@ -54,6 +54,7 @@ transformOver = transT where
   mapT s (Atom a) = Atom (transA s a)
   mapT s (App f a) = App (transA s f) (transA s a)
   mapT s (TyApp f t) = TyApp (transA s f) t
+  mapT s (Cast f t) = Cast (transA s f) t
   mapT s (Extend t rs) = Extend (transA s t) (map (third3 (transA s)) rs)
   mapT s (Let vars body) =
     let vars' = map (third3 (transT (extendVars vars s))) vars

--- a/src/Core/Simplify.hs
+++ b/src/Core/Simplify.hs
@@ -3,6 +3,7 @@ module Core.Simplify
   ) where
 
 import Core.Optimise.DeadCode
+import Core.Optimise.Newtype
 import Core.Optimise.Inline
 import Core.Optimise.Reduce
 import Core.Optimise
@@ -18,6 +19,7 @@ optmOnce = pure . passes where
            , reducePass
            , inlineVariablePass
            , deadCodePass
+           , killNewtypePass
            ]
 
 optimise :: [Stmt (Var Resolved)] -> Gen Int [Stmt (Var Resolved)]

--- a/src/Core/Simplify.hs
+++ b/src/Core/Simplify.hs
@@ -9,17 +9,18 @@ import Core.Optimise.Reduce
 import Core.Optimise
 
 import Control.Monad.Gen
+import Control.Monad
 
 import Syntax (Var(..), Resolved)
 
 optmOnce :: [Stmt (Var Resolved)] -> Gen Int [Stmt (Var Resolved)]
-optmOnce = pure . passes where
+optmOnce = pure . passes <=< killNewtypePass where
   passes = foldr (.) id $ reverse
            [ id
            , reducePass
            , inlineVariablePass
            , deadCodePass
-           , killNewtypePass
+           , reducePass
            ]
 
 optimise :: [Stmt (Var Resolved)] -> Gen Int [Stmt (Var Resolved)]

--- a/src/Core/Simplify.hs
+++ b/src/Core/Simplify.hs
@@ -14,13 +14,17 @@ import Control.Monad
 import Syntax (Var(..), Resolved)
 
 optmOnce :: [Stmt (Var Resolved)] -> Gen Int [Stmt (Var Resolved)]
-optmOnce = pure . passes <=< killNewtypePass where
-  passes = foldr (.) id $ reverse
-           [ id
-           , reducePass
+optmOnce = passes where
+  passes = foldr1 (>=>)
+           [ pure
+
+           , pure . reducePass
            , inlineVariablePass
-           , deadCodePass
-           , reducePass
+
+           , pure . deadCodePass
+           , killNewtypePass
+
+           , pure . reducePass
            ]
 
 optimise :: [Stmt (Var Resolved)] -> Gen Int [Stmt (Var Resolved)]

--- a/src/Core/Types.hs
+++ b/src/Core/Types.hs
@@ -36,17 +36,9 @@ approximateAtomType (Lit l) = pure . fmap fromVar $ case l of
   Unit -> cotyUnit
   RecNil -> ExactRowsTy []
 
-doCast :: IsVar a => Coercion a -> Type a -> Maybe (Type a)
-doCast (SameRepr t t') i = case unify t i of
-  Just _ -> pure t'
-  _ -> Nothing
-doCast (Domain c) (ArrTy x t) = ArrTy <$> doCast c x <*> pure t
-doCast (Codomain c) (ArrTy t x) = ArrTy t <$> doCast c x
-doCast _ _ = Nothing
-
 approximateType :: IsVar a => Term a -> Maybe (Type a)
 approximateType (Atom a) = approximateAtomType a
-approximateType (Cast t phi) = doCast phi =<< approximateAtomType t
+approximateType (Cast _ phi) = snd <$> relates phi
 approximateType (App f _) = do
   ArrTy _ d <- approximateAtomType f
   pure d


### PR DESCRIPTION
This PR adds terms of the form `x |> phi` where x is an atom and `phi` is a _coercion_. Coercions are a zero-cost way to witness an isomorphism between two types at compile time (which, (un)fortunately, the users can't exploit. yet.)

Coercions have one of the following forms:

- `a ~ b` relates the types `a` and `b`
- `dom phi`, where phi relates `a -> x` and `b -> y`, relates `a` and `b`
- `cod phi`, where phi relates `a -> x` and `b -> y`, relates `x` and `y`

Types of the form

```ocaml
type foo = Foo of a
```

become

```ocaml
type foo ...

let Foo x = (x |> a ~ foo)
```

Similarly, matching becomes matching on casts.