### PR TITLE
Feature/why skolem

### DIFF
--- a/src/Core/Lower.hs
+++ b/src/Core/Lower.hs
@@ -198,7 +198,7 @@ lowerType (S.TyRows rho vs) = RowsTy (lowerType rho) (map (fmap lowerType) vs)
 lowerType (S.TyExactRows vs) = ExactRowsTy (map (fmap lowerType) vs)
 lowerType (S.TyVar (TvName v)) = VarTy v
 lowerType (S.TyCon (TvName v)) = ConTy v
-lowerType (S.TySkol (Skolem _ (TvName v) _)) = VarTy v
+lowerType (S.TySkol (Skolem _ (TvName v) _ _)) = VarTy v
 lowerType (S.TyWithConstraints _ t) = lowerType t
 
 tup2Rec :: Int -> S.Type Typed -> [(T.Text, Type)]

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -146,16 +146,26 @@ data Skolem p
   = Skolem { _skolIdent :: Var p -- the constant itself
            , _skolVar :: Var p -- what variable this skolemises
            , _skolScope :: Type p -- the type this was generated for
+           , _skolMotive :: SkolemMotive p
            }
 
 deriving instance (Show (Var p), Show (Ann p)) => Show (Skolem p)
 deriving instance (Data p, Typeable p, Data (Var p), Data (Ann p)) => Data (Skolem p)
 
+data SkolemMotive p
+  = ByAscription
+  | BySubsumption (Type p) (Type p)
+  | ByExistential (Var p) (Type p)
+
+deriving instance (Show (Var p), Show (Ann p)) => Show (SkolemMotive p)
+deriving instance (Data p, Typeable p, Data (Var p), Data (Ann p)) => Data (SkolemMotive p)
+
+
 instance Eq (Var p) => Eq (Skolem p) where
-  Skolem v _ _  == Skolem v' _ _ = v == v'
+  Skolem v _ _ _ == Skolem v' _ _ _ = v == v'
 
 instance Ord (Var p) => Ord (Skolem p) where
-  Skolem v _ _ `compare` Skolem v' _ _ = v `compare` v'
+  Skolem v _ _ _ `compare` Skolem v' _ _ _ = v `compare` v'
 
 deriving instance (Eq (Var p), Eq (Ann p)) => Eq (Type p)
 deriving instance (Show (Var p), Show (Ann p)) => Show (Type p)

--- a/src/Syntax/Pretty.hs
+++ b/src/Syntax/Pretty.hs
@@ -6,6 +6,7 @@ module Syntax.Pretty
   ) where
 
 import Control.Arrow (first, second)
+import Control.Lens
 
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
@@ -90,7 +91,7 @@ instance Pretty Lit where
 instance (Pretty (Var p)) => Pretty (Type p) where
   pretty (TyCon v) = stypeCon (pretty v)
   pretty (TyVar v) = stypeVar (squote <> pretty v)
-  pretty (TySkol (Skolem v _ _)) = stypeSkol (pretty v)
+  pretty (TySkol v) = stypeSkol (pretty (v ^. skolIdent))
   pretty (TyForall vs v)
     = keyword "forall" <+> hsep (map (stypeVar . (squote <>) . pretty) vs) <> dot <+> pretty v
 

--- a/src/Syntax/Pretty.hs
+++ b/src/Syntax/Pretty.hs
@@ -20,12 +20,12 @@ parenFun f = case f of
   Fun{} -> parens (pretty f)
   Let{} -> parens (pretty f)
   Match{} -> parens (pretty f)
-  App{} -> parens (pretty f)
   _ -> pretty f
 
 parenArg :: Pretty (Var p) => Expr p -> Doc
 parenArg f = case f of
   TypeApp{} -> parens (pretty f)
+  App{} -> parens (pretty f)
   _ -> parenFun f
 
 instance (Pretty (Var p)) => Pretty (Expr p) where

--- a/src/Syntax/Raise.hs
+++ b/src/Syntax/Raise.hs
@@ -51,7 +51,10 @@ raiseP v a (PTuple e p) = PTuple (map (raiseP v a) e) (a p)
 raiseT :: (Var p -> Var p') -- How to raise variables
        -> Type p -> Type p'
 raiseT v (TyCon n) = TyCon (v n)
-raiseT v (TySkol (Skolem n u t)) = TySkol (Skolem (v n) (v u) (raiseT v t))
+raiseT v (TySkol (Skolem n u t m)) = TySkol (Skolem (v n) (v u) (raiseT v t) (motive m)) where
+  motive (BySubsumption a b) = BySubsumption (raiseT v a) (raiseT v b)
+  motive ByAscription = ByAscription
+  motive (ByExistential a t) = ByExistential (v a) (raiseT v t)
 raiseT v (TyVar n) = TyVar (v n)
 raiseT v (TyForall n t) = TyForall (map v n) (raiseT v t)
 raiseT v (TyArr x y) = TyArr (raiseT v x) (raiseT v y)

--- a/src/Types/Kinds.hs
+++ b/src/Types/Kinds.hs
@@ -63,7 +63,7 @@ inferKind tp = do
     TyVar x -> do
       ki <- view (types . at (unTvName x))
       maybe freshKV pure ki
-    TySkol (Skolem x _ _) -> do
+    TySkol (Skolem x _ _ _) -> do
       ki <- view (types . at (unTvName x))
       maybe freshKV pure ki
     TyCon x -> do


### PR DESCRIPTION
Track *why* a variable was skolemised in addition to what it was skolemised from and what scope it was skolemised in. This lets us have mildly better error messages, such as
this one for an existential escaping:
    
    <test>[4:14 ..4:28]: error
      Rigid type variable o has escaped its scope of ('o -> string * 'o) -> box
      · Note: the variable o was rigidified because it is an existential,
              bound by the type of Box, ('o -> string * 'o) -> box,
              and is represented by constant p
    
      · Note: in type `box -> p -> string`
      · Note: in the inferred type for show_it
      · Arising from use of the expression
          fun (Box (f, x)) -> f
       │
     4 │ let show_it (Box (f, x)) = f
       │              ~~~~~~~~~~~~~~~
