### PR TITLE
Add an allocation sinking pass

### DIFF
--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -101,6 +101,7 @@ library amulet
                      , Data.Spanned
                      -- Core
                      , Core.Core
+                     , Core.Free
                      , Core.Lower
                      , Core.Types
                      , Core.Optimise
@@ -108,6 +109,7 @@ library amulet
                      , Core.Occurrence
                      , Core.Optimise.Reduce
                      , Core.Optimise.Inline
+                     , Core.Optimise.Sinking
                      , Core.Optimise.Newtype
                      , Core.Optimise.DeadCode
                      -- Backend

--- a/src/Core/Free.hs
+++ b/src/Core/Free.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE ScopedTypeVariables, ExplicitNamespaces #-}
+module Core.Free
+  ( tagFreeSet, freeSet
+  , tagFreeStmt, tagFreeTerm
+  ) where
+
+import Core.Core as C
+
+import qualified Data.VarSet as VarSet
+import Data.VarSet (IsVar(..))
+import Data.Semigroup
+import Data.Triple
+
+freeSet :: IsVar a => [AnnStmt b a] -> VarSet.Set
+freeSet = fst . tagFreeStmt const const
+
+tagFreeSet :: IsVar a => [AnnStmt b a] -> [AnnStmt VarSet.Set a]
+tagFreeSet = snd . tagFreeStmt (flip const) const
+
+tagFreeStmt :: forall a a' b b'. (IsVar a, IsVar a')
+             => (b -> VarSet.Set -> b')
+             -> (a -> Bool -> a')
+             -> [AnnStmt b a] -> (VarSet.Set, [AnnStmt b' a'])
+tagFreeStmt ann var = tagStmt where
+  conv = fmap (`var` True)
+  var' v = var v . VarSet.member (toVar v)
+
+  tagStmt :: [AnnStmt b a] -> (VarSet.Set, [AnnStmt b' a'])
+  tagStmt [] = (mempty, [])
+  tagStmt (Foreign v ty txt:xs) =
+    let (fv, xs') = tagStmt xs
+    in ( toVar v `VarSet.delete` fv
+       , Foreign (var' v fv) (conv ty) txt:xs')
+  tagStmt (Type v tys:xs) =
+    let (fv, xs') = tagStmt xs
+    in ( fv
+       , Type (var v True) (map (tagCons fv) tys):xs') where
+      tagCons fv (cons, ty) = (var' cons fv, conv ty)
+  tagStmt (StmtLet vs:xs) =
+    let (fvxs, xs') = tagStmt xs
+        (fvvs, vs') = unzip (map (tagFreeTerm ann var . thd3) vs)
+
+        fvs = mconcat (fvxs : fvvs)
+        fv = foldr (VarSet.delete . toVar . fst3) fvs vs
+    in (fv, StmtLet (zipWith (\(v, ty, _) e -> (var' v fvs, conv ty, e)) vs vs'):xs')
+
+tagFreeTerm :: forall a a' b b' . (IsVar a, IsVar a')
+             => (b -> VarSet.Set -> b')
+             -> (a -> Bool -> a')
+             -> AnnTerm b a -> (VarSet.Set, AnnTerm b' a')
+tagFreeTerm ann var = tagTerm where
+  conv :: Functor f => f a -> f a'
+  conv = fmap (`var` True)
+
+  var' v = var v . VarSet.member (toVar v)
+
+  tagAtom (Lit l) = (mempty, Lit l)
+  tagAtom (Ref a ty) = (VarSet.singleton (toVar a)
+                       , Ref (var a True) (conv ty))
+  tagAtom (Lam (TermArgument arg ty) bod) =
+    let (fv, bod') = tagTerm bod
+    in (VarSet.delete (toVar arg) fv
+       , Lam (TermArgument (var' arg fv) (conv ty)) bod')
+  tagAtom (Lam (TypeArgument arg ty) bod) =
+    let (fv, bod') = tagTerm bod
+    in (fv
+       , Lam (TypeArgument (var arg True) (conv ty)) bod')
+
+  tagTerm (AnnAtom an a) =
+    let (fv, a') = tagAtom a
+    in (fv, AnnAtom (ann an fv) a')
+
+  tagTerm (AnnApp an f x) =
+    let (fvf, f') = tagAtom f
+        (fvx, x') = tagAtom x
+        fv = fvf <> fvx
+    in (fv, AnnApp (ann an fv) f' x')
+
+  tagTerm (AnnLet an (One (v, ty, e)) r) =
+    let (fve, e') = tagTerm e
+        (fvr, r') = tagTerm r
+        fv = fve <> VarSet.delete (toVar v) fvr
+    in (fv, AnnLet (ann an fv) (One (var' v fvr, conv ty, e')) r')
+  tagTerm (AnnLet an (Many vs) r) =
+    let (fvvs, vs') = unzip (map (tagTerm . thd3) vs)
+        (fvr, r') = tagTerm r
+
+        fvs = mconcat (fvr : fvvs)
+        fv = foldr (VarSet.delete . toVar . fst3) fvs vs
+    in (fv, AnnLet (ann an fv) (Many (zipWith (\(v, ty, _) e -> (var' v fvs, conv ty, e)) vs vs')) r')
+
+  tagTerm (AnnMatch an t bs) =
+    let (fvt, t') = tagAtom t
+        (ftbs, bs') = unzip (map tagPtrn bs)
+        fv = mconcat (fvt : ftbs)
+    in (fv, AnnMatch (ann an fv) t' bs') where
+      tagPtrn (p, ty, b) =
+        let (fvb, b') = tagTerm b
+            p' = flip var' fvb <$> p
+            pv = patternVarsA p :: [a]
+        in (foldr (VarSet.delete . toVar) fvb pv, (p', conv ty, b'))
+
+  tagTerm (AnnExtend an f fs) =
+    let (fvf, f') = tagAtom f
+        (fvfs, fs') = unzip (map (\(n, ty, a) ->
+                                     let (fva, a') = tagAtom a
+                                     in (fva, (n, conv ty, a'))) fs)
+        fv = mconcat (fvf : fvfs)
+    in (fv, AnnExtend (ann an fv) f' fs')
+
+  tagTerm (AnnTyApp an f ty) =
+    let (fv, f') = tagAtom f
+    in (fv, AnnTyApp (ann an fv) f' (conv ty))
+
+  tagTerm (AnnCast an x co) =
+    let (fv, x') = tagAtom x
+    in (fv, AnnCast (ann an fv) x' (conv co))

--- a/src/Core/Optimise/Sinking.hs
+++ b/src/Core/Optimise/Sinking.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE TupleSections #-}
+module Core.Optimise.Sinking (sinkingPass) where
+
+import qualified Data.VarSet as VarSet
+import Data.VarSet (IsVar(..))
+import Data.Triple
+
+import Core.Optimise
+
+data Sinkable a = Sinkable { sBind  :: (a, Type a, Term a)
+                           , sFree  :: VarSet.Set
+                           , sBound :: VarSet.Set }
+  deriving (Show)
+
+data SinkState a = SinkState { sinkable :: [Sinkable a]
+                             , ctors :: VarSet.Set }
+  deriving (Show)
+
+{-
+The allocation sinking pass (also referred to as float-in or lambda dropping)
+moves pure expressions closer to where they are used. If an expression is only
+used within a single branch of a match case, then it will be moved into that
+case.
+
+This hopefully reduces the times when allocation is needed, as only code paths
+which require the value actually execute it.
+
+This operates very much as you'd expect: keep track of which variables we're
+trying to sink, determine if they can be sunk to the next level and, if not,
+emit their corresponding bindings here. The main exception to this rule is
+lambdas, as one should not shift values _inside_ lambdas: that could lead to
+duplicating work instead.
+
+The current purity tracking is rather naive: atoms, constructors and records are
+the only "pure" expressions. It may be a good idea to extend this in the future
+to include partially applied functions (like the DCE pass does).
+
+-}
+
+sinkingPass :: IsVar a => [AnnStmt VarSet.Set a] -> [Stmt a]
+sinkingPass = sinkStmts (SinkState [] mempty)
+
+sinkStmts :: IsVar a => SinkState a -> [AnnStmt VarSet.Set a] -> [Stmt a]
+sinkStmts _ [] = []
+sinkStmts s (Foreign v ty bod:xs) = Foreign v ty bod:sinkStmts s xs
+sinkStmts s (StmtLet vars:xs) =
+  let vars' = map (third3 (sinkTerm s)) vars
+  in StmtLet vars':sinkStmts s xs
+sinkStmts s (Type v cases:xs) =
+  let s' = s { ctors = VarSet.union (VarSet.fromList (map (toVar . fst) cases)) (ctors s) }
+  in Type v cases:sinkStmts s' xs
+
+sinkAtom :: IsVar a => SinkState a -> AnnAtom VarSet.Set a -> Atom a
+sinkAtom _ (Lit l) = Lit l
+sinkAtom _ (Ref v ty) = Ref v ty
+sinkAtom s (Lam var term) = Lam var (sinkTerm s term)
+
+sinkTerm :: IsVar a => SinkState a -> AnnTerm VarSet.Set a -> Term a
+sinkTerm s (AnnAtom _ a) = flushBinds (sinkable s) (Atom (sinkAtom (nullBinds s) a))
+sinkTerm s (AnnApp _ f x) = flushBinds (sinkable s) (App (sinkAtom s' f) (sinkAtom s' x))
+  where s' = nullBinds s
+
+sinkTerm s (AnnLet _ (One (v, ty, e)) r)
+  -- If we're pure, add it to the sink set
+  | isPure s e
+  = let e' = sinkTerm (nullBinds s) e
+        s' = s { sinkable = Sinkable { sBind = (v, ty, e')
+                                     , sBound = VarSet.singleton (toVar v)
+                                     , sFree = extractAnn e } : sinkable s }
+    in sinkTerm s' r
+
+  -- Otherwise, partition into sinkable/nonsinkable
+  | otherwise
+  = let (fs, [rs, es]) = partitionBinds (sinkable s) [extractAnn r, extractAnn e]
+        e' = sinkTerm (s { sinkable = es }) e
+        r' = sinkTerm (s { sinkable = rs }) r
+    in flushBinds fs (Let (One (v, ty, e')) r')
+
+sinkTerm s (AnnLet _ (Many vs) r) =
+  let (fs, rs:vss) = partitionBinds (sinkable s) (extractAnn r : map (extractAnn . thd3) vs)
+      vs' = zipWith (\fv -> third3 (sinkTerm (s { sinkable = fv }))) vss vs
+      r'  = sinkTerm (s { sinkable = rs }) r
+  in flushBinds fs (Let (Many vs') r')
+
+sinkTerm s (AnnMatch _ t bs) =
+  let (fs, ts:bss) = partitionBinds (sinkable s) (freeInAtom t : map (extractAnn . thd3) bs)
+      t' = sinkAtom (nullBinds s) t
+      bs' = zipWith (\fv -> third3 (sinkTerm (s { sinkable = fv }))) bss bs
+  in flushBinds fs $ flushBinds ts $ Match t' bs'
+
+sinkTerm s (AnnExtend _ f fs) = flushBinds (sinkable s) (Extend (sinkAtom s' f) (map (third3 (sinkAtom s')) fs))
+  where s' = nullBinds s
+
+sinkTerm s (AnnTyApp _ f ty) = flushBinds (sinkable s) (TyApp (sinkAtom (nullBinds s) f) ty)
+sinkTerm s (AnnCast _ f co) = flushBinds (sinkable s) (Cast (sinkAtom (nullBinds s) f) co)
+
+flushBinds :: [Sinkable a] -> Term a -> Term a
+flushBinds [] t = t
+flushBinds (si@Sinkable{}:xs) t = Let (One (sBind si)) (flushBinds xs t)
+
+nullBinds :: SinkState a -> SinkState a
+nullBinds s = s { sinkable = [] }
+
+partitionBinds
+  :: IsVar a
+  => [Sinkable a] -- Terms which may be sunk
+  -> [VarSet.Set] -- Free variables of the places which these terms may be sunk into
+  -> ([Sinkable a], [[Sinkable a]]) -- A tuple of non-sunk terms and a list with sunken terms, with
+                                    -- each entry corresponding to an entry in the places list.
+partitionBinds sink free = go sink (mempty, []) (map (,[]) free) where
+  go [] (_, here) binds = (reverse here, map (reverse . snd) binds)
+  go (si:sis) here binds =
+    if occursIn si here
+    then
+      -- If any term dependent on this occurs here, we should emit this binding here
+      go sis (insertSink si here) binds
+    else
+      -- Find which branches depend on one of these variables
+      let usedIn = map (occursIn si) binds
+      in case length (filter id usedIn) of
+           1 -> go sis here (zipWith (insertMaybe si) binds usedIn)
+           _ -> go sis (insertSink si here) binds
+
+  insertSink si@Sinkable{} (free, sis) = (sFree si `VarSet.union` free, si:sis)
+  insertMaybe _  bind False = bind
+  insertMaybe si bind True = insertSink si bind
+
+  occursIn si = not . VarSet.isEmpty . VarSet.intersection (sBound si) . fst
+
+
+isPure :: IsVar a => SinkState a -> AnnTerm b a -> Bool
+isPure _ AnnAtom{}   = True
+isPure _ AnnExtend{} = True
+isPure _ AnnTyApp{}  = True
+isPure _ AnnCast{}   = True
+isPure s (AnnApp _ (Ref f _) _) | toVar f `VarSet.member` ctors s = True
+isPure _ _ = False

--- a/src/Core/Simplify.hs
+++ b/src/Core/Simplify.hs
@@ -6,7 +6,10 @@ import Core.Optimise.DeadCode
 import Core.Optimise.Newtype
 import Core.Optimise.Inline
 import Core.Optimise.Reduce
+import Core.Optimise.Sinking
 import Core.Optimise
+
+import Core.Free
 
 import Control.Monad.Gen
 import Control.Monad
@@ -23,6 +26,7 @@ optmOnce = passes where
 
            , pure . deadCodePass
            , killNewtypePass
+           , pure . sinkingPass . tagFreeSet
 
            , pure . reducePass
            ]


### PR DESCRIPTION
Almost 1/8th the size of GHC's equivalent, this sinks any pure expression down the tree to be as close to its use-site as possible, potentially reducing the number of allocations/operations which are required. For instance, this'll reduce:

```ml
let main x = let y = (1, x)
             in match x with
                | Nil -> fun _ -> y
                | _ -> fun x -> (x, Nil)
```
into
```ml
let main x = match x with
             | Nil -> let y = (1, x)
                      in fun _ -> y
             | _ -> fun x -> (x, Nil)
```

There are definitely some enhancements we could make to this (such as duplicating trivial expressions across matches or considering partially applied functions as "pure"), but this'll do for now.