### PR TITLE
Add an application operator, @@

### DIFF
--- a/src/Parser.y
+++ b/src/Parser.y
@@ -47,6 +47,7 @@ import Syntax
   '<>'     { Token TcNotEqual _ }
   '~'      { Token TcTilde _ }
   '_'      { Token TcUnderscore _ }
+  '@@'     { Token TcAtAt _ }
 
   '**.'    { Token TcDoubleStarFloat _ }
   '*.'     { Token TcStarFloat _ }
@@ -110,6 +111,7 @@ import Syntax
 %left '*' '/' '*.' '/.'
 %right '**' '**.'
 %left opid qopid
+%right '@@'
 
 %%
 
@@ -156,6 +158,7 @@ Expr :: { Expr Parsed }
      | Expr '||' Expr                          { withPos2 $1 $3 $ BinOp $1 (withPos1 $2 $ varE "||") $3 }
      | Expr opid Expr                          { withPos2 $1 $3 $ BinOp $1 (withPos1 $2 $ VarRef (getName $2)) $3 }
      | Expr qopid Expr                         { withPos2 $1 $3 $ BinOp $1 (withPos1 $2 $ VarRef (getName $2)) $3 }
+     | Expr '@@' Expr                          { withPos2 $1 $3 $ App $1 $3 }
 
 ExprApp :: { Expr Parsed }
         : Expr0                                { $1 }

--- a/src/Parser/Lexer.x
+++ b/src/Parser/Lexer.x
@@ -60,6 +60,7 @@ tokens :-
   <0> "-"      { constTok TcSubtract }
   <0> "<>"     { constTok TcNotEqual }
   <0> "~"      { constTok TcTilde }
+  <0> "@@"     { constTok TcAtAt }
   <0> \_       { constTok TcUnderscore }
 
   <0> "**."    { constTok TcDoubleStarFloat }

--- a/src/Parser/Token.hs
+++ b/src/Parser/Token.hs
@@ -29,6 +29,7 @@ data TokenClass
   | TcNotEqual -- <>
   | TcTilde -- ~
   | TcUnderscore -- _
+  | TcAtAt -- @@
 
   | TcLet -- let
   | TcAnd -- and
@@ -100,6 +101,7 @@ instance Show TokenClass where
   show TcNotEqual = "<>"
   show TcTilde = "~"
   show TcUnderscore = "_"
+  show TcAtAt = "@@"
 
   show TcAddFloat = "+."
   show TcSubtractFloat = "-."


### PR DESCRIPTION
It's a hack. It's allowed to be impredicative, because it's not even a
thing in the abstract syntax: `f @@ x y` _parses the same as_ `f (x y)`.
Not _desugars to_ `f (x y)`, mind you: we do it in the parser.
