### PR TITLE
Generate Correct Evidence

### DIFF
--- a/examples/gadt/equality.ml
+++ b/examples/gadt/equality.ml
@@ -16,10 +16,10 @@ end ;;
 
 let s_is_k (x : 'a) : Equality.t (s 'a) (k 'a) = unsafe_coerce Equality.Refl
 
-and s_to_k (S x) = Equality.subst (s_is_k x) (S x)
-and k_to_s (K x) = Equality.subst (Equality.sym (s_is_k x)) (K x)
+(* and s_to_k (S x) = Equality.subst (s_is_k x) (S x) *)
+(* and k_to_s (K x) = Equality.subst (Equality.sym (s_is_k x)) (K x) *)
 
-and k_to_s_to_k x = s_to_k (k_to_s x)
-and s_to_k_to_s x = k_to_s (s_to_k x) ;;
+(* and k_to_s_to_k x = s_to_k (k_to_s x) *)
+(* and s_to_k_to_s x = k_to_s (s_to_k x) ;; *)
 
-let main = print (s_to_k (S 1))
+(* let main = print (s_to_k (S 1)) *)

--- a/examples/gadt/equality.ml
+++ b/examples/gadt/equality.ml
@@ -16,10 +16,10 @@ end ;;
 
 let s_is_k (x : 'a) : Equality.t (s 'a) (k 'a) = unsafe_coerce Equality.Refl
 
-(* and s_to_k (S x) = Equality.subst (s_is_k x) (S x) *)
-(* and k_to_s (K x) = Equality.subst (Equality.sym (s_is_k x)) (K x) *)
+and s_to_k (S x) = Equality.subst (s_is_k x) (S x)
+and k_to_s (K x) = Equality.subst (Equality.sym (s_is_k x)) (K x)
 
-(* and k_to_s_to_k x = s_to_k (k_to_s x) *)
-(* and s_to_k_to_s x = k_to_s (s_to_k x) ;; *)
+and k_to_s_to_k x = s_to_k (k_to_s x)
+and s_to_k_to_s x = k_to_s (s_to_k x) ;;
 
-(* let main = print (s_to_k (S 1)) *)
+let main = print (s_to_k (S 1))

--- a/src/Core/Core.hs
+++ b/src/Core/Core.hs
@@ -14,8 +14,6 @@ import Control.Lens.Plated
 
 import GHC.Generics
 
-import Debug.Trace
-
 import Syntax (Var(..), Resolved)
 
 data AnnAtom b a
@@ -151,8 +149,8 @@ instance Pretty a => Pretty (Coercion a) where
   pretty (SameRepr a b) = pretty a <+> soperator (char '~') <+> pretty b
   pretty (Application c c') = pretty c <+> pretty c'
   pretty (Arrow c c') = pretty c <+> arrow <+> pretty c'
-  pretty (Record r s) = error "todo"
-  pretty (ExactRecord _) = error "todo"
+  pretty (Record r s) = enclose (lbrace <> space) (space <> rbrace) (pretty r <+> hsep (punctuate comma (map pprCoRow s)))
+  pretty (ExactRecord r) = enclose (lbrace <> space) (space <> rbrace) (hsep (punctuate comma (map pprCoRow r)))
   pretty (Domain f) = keyword "dom" <+> parens (pretty f)
   pretty (Codomain f) = keyword "cod" <+> parens (pretty f)
   pretty (Symmetry f) = keyword "sym" <+> parens (pretty f)
@@ -170,6 +168,9 @@ pprBegin = braces' . vsep . map (indent 2) . punctuate semi
 pprCases :: Pretty a => [(Pattern a, Type a, Term a)] -> Doc
 pprCases = braces' . vsep . map (indent 2) . punctuate semi . map one where
   one (a, b, c) = pretty a <+> colon <+> pretty b <+> nest 2 (arrow </> pretty c)
+
+pprCoRow :: Pretty a => (Text, Coercion a) -> Doc
+pprCoRow (a, b) = text a <+> equals <+> pretty b
 
 braces' :: Doc -> Doc
 braces' = enclose (lbrace <> linebreak) (linebreak <> rbrace)

--- a/src/Core/Core.hs
+++ b/src/Core/Core.hs
@@ -14,6 +14,8 @@ import Control.Lens.Plated
 
 import GHC.Generics
 
+import Debug.Trace
+
 import Syntax (Var(..), Resolved)
 
 data AnnAtom b a
@@ -282,12 +284,14 @@ patternVarsA (PatExtend p ps) = mconcat (patternVarsA p : map (patternVarsA . sn
 patternVarsA Constr{} = mempty
 patternVarsA PatLit{} = mempty
 
-relates :: Coercion a -> Maybe (Type a, Type a)
+relates :: Show a => Coercion a -> Maybe (Type a, Type a)
 relates (SameRepr a b) = Just (a, b)
 relates (CoercionVar _) = Nothing
-relates (Application f _) = do
-  (ArrTy _ c, ArrTy _ d) <- relates f
-  pure (c, d)
+relates (Application f x) = do
+  (f, g) <- relates f
+  (x, y) <- relates x
+  pure (AppTy f x, AppTy g y)
+
 relates (Arrow x y) = do
   (a, b) <- relates x
   (c, d) <- relates y

--- a/src/Core/Optimise.hs
+++ b/src/Core/Optimise.hs
@@ -53,7 +53,10 @@ substituteInTys m = term where
   coercion (Domain c) = Domain (coercion c)
   coercion (Codomain c) = Codomain (coercion c)
   coercion (Symmetry c) = Symmetry (coercion c)
-  coercion (Composition c c') = Composition (coercion c) (coercion c')
+  coercion (Application f x) = Application (coercion f) (coercion x)
+  coercion (Arrow f x) = Arrow (coercion f) (coercion x)
+  coercion (ExactRecord rs) = ExactRecord (map (second coercion) rs)
+  coercion (Record c rs) = Record (coercion c) (map (second coercion) rs)
   coercion (CoercionVar x) = CoercionVar x
 
   atom (Ref v t) = Ref v (gotype t)
@@ -81,7 +84,10 @@ substituteInCo m = coercion where
   coercion (Domain c) = Domain (coercion c)
   coercion (Codomain c) = Codomain (coercion c)
   coercion (Symmetry c) = Symmetry (coercion c)
-  coercion (Composition c c') = Composition (coercion c) (coercion c')
+  coercion (Application f x) = Application (coercion f) (coercion x)
+  coercion (Arrow f x) = Arrow (coercion f) (coercion x)
+  coercion (ExactRecord rs) = ExactRecord (map (second coercion) rs)
+  coercion (Record c rs) = Record (coercion c) (map (second coercion) rs)
   coercion (CoercionVar x) = CoercionVar x
 
   gotype = substituteInType m
@@ -160,7 +166,10 @@ refresh = refreshTerm mempty where
   refreshCoercion s (Domain c) = Domain (refreshCoercion s c)
   refreshCoercion s (Codomain c) = Codomain (refreshCoercion s c)
   refreshCoercion s (Symmetry c) = Symmetry (refreshCoercion s c)
-  refreshCoercion s (Composition c c') = Composition (refreshCoercion s c) (refreshCoercion s c')
+  refreshCoercion s (Application f x) = Application (refreshCoercion s f) (refreshCoercion s x)
+  refreshCoercion s (ExactRecord rs) = ExactRecord (map (second (refreshCoercion s)) rs)
+  refreshCoercion s (Record c rs) = Record (refreshCoercion s c) (map (second (refreshCoercion s)) rs)
+  refreshCoercion s (Arrow f x) = Arrow (refreshCoercion s f) (refreshCoercion s x)
   refreshCoercion s x@(CoercionVar v) = maybe x CoercionVar (VarMap.lookup (toVar v) s)
 
 argVar :: IsVar a => Argument a -> Var _

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -177,7 +177,7 @@ data Coercion p
   = VarCo (Var p)
   | ReflCo (Type p) -- <T> : T ~ T
   | SymCo (Coercion p) -- sym (X : T ~ S) : S ~ T
-  | AppCo (Coercion p) (Coercion p) -- (f : (A -> B) ~ (C -> D)) (x : A ~ C) : B ~ D
+  | AppCo (Coercion p) (Coercion p) -- (f : B ~ D) (x : A ~ C) : B A ~ D C
   | ArrCo (Coercion p) (Coercion p) -- (x : S ~ T) -> (y : S' ~ T') : (S -> S') ~ (T -> T')
   | ProdCo (Coercion p) (Coercion p) -- (x : S ~ T, y : S' ~ T') : (S, S') ~ (T, T')
   | ExactRowsCo [(Text, Coercion p)] -- { x : A ~ B } : { x : A } ~ { x : B }

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -175,9 +175,14 @@ deriving instance (Data p, Typeable p, Data (Var p), Data (Ann p)) => Data (Type
 
 data Coercion p
   = VarCo (Var p)
-  | ReflCo (Type p) (Type p)
-  | CompCo (Coercion p) (Coercion p)
-  | SymCo (Coercion p)
+  | ReflCo (Type p) -- <T> : T ~ T
+  | SymCo (Coercion p) -- sym (X : T ~ S) : S ~ T
+  | AppCo (Coercion p) (Coercion p) -- (f : (A -> B) ~ (C -> D)) (x : A ~ C) : B ~ D
+  | ArrCo (Coercion p) (Coercion p) -- (x : S ~ T) -> (y : S' ~ T') : (S -> S') ~ (T -> T')
+  | ProdCo (Coercion p) (Coercion p) -- (x : S ~ T, y : S' ~ T') : (S, S') ~ (T, T')
+  | ExactRowsCo [(Text, Coercion p)] -- { x : A ~ B } : { x : A } ~ { x : B }
+  | RowsCo (Coercion p) [(Text, Coercion p)] -- { x : A ~ B | f : S ~ T } : { A | f : S } ~ { B | f : T }
+  | AssumedCo (Type p) (Type p) -- <A, B> : A ~ B
 
 deriving instance (Eq (Var p), Eq (Ann p)) => Eq (Coercion p)
 deriving instance (Show (Var p), Show (Ann p)) => Show (Coercion p)

--- a/src/Syntax/Pretty.hs
+++ b/src/Syntax/Pretty.hs
@@ -68,9 +68,14 @@ instance (Pretty (Var p)) => Pretty (Expr p) where
   pretty (TypeApp f x _) = parenFun f <+> soperator (char '@') <> braces (pretty x)
   pretty (Cast e c _) = parens (pretty e <+> soperator (string "|>") <+> pprCo c) where
     pprCo (VarCo x) = stypeSkol (pretty x)
-    pprCo (ReflCo t t') = pretty t <+> soperator (char '~') <+> pretty t'
-    pprCo (CompCo c c') = pprCo c <+> soperator (char ';') <+> pprCo c'
+    pprCo (ReflCo t) = enclose (char '<') (char '>') (pretty t)
+    pprCo (AssumedCo a b) = enclose (char '<') (char '>') (pretty a <> comma <+> pretty b)
     pprCo (SymCo x) = keyword "sym" <+> pprCo x
+    pprCo (AppCo f x) = pprCo f <+> pprCo x
+    pprCo (ArrCo f x) = pprCo f <+> arrow <+> pprCo x
+    pprCo (ProdCo f x) = pprCo f <+> prod <+> pprCo x
+    pprCo (ExactRowsCo rs) = record (map (\(n, v) -> text n <+> colon <+> pprCo v) rs)
+    pprCo (RowsCo c rs) = enclose (lbrace <> space) (space <> rbrace) (pprCo c <+> pipe <+> hsep (punctuate comma (map (\(n, v) -> text n <+> colon <+> pprCo v) rs)))
 
 prettyMatches :: (Pretty (Var p)) => [(Pattern p, Expr p)] -> [Doc]
 prettyMatches = map (\(a, b) -> pipe <+> nest 4 (pretty a <+> arrow </> pretty b))

--- a/src/Syntax/Raise.hs
+++ b/src/Syntax/Raise.hs
@@ -69,6 +69,11 @@ raiseT v (TyWithConstraints eq a) = TyWithConstraints (map (\(a, b) -> (raiseT v
 
 raiseCo :: (Var p -> Var p') -> Coercion p -> Coercion p'
 raiseCo v (VarCo a) = VarCo (v a)
-raiseCo v (ReflCo t t') = ReflCo (raiseT v t) (raiseT v t')
-raiseCo v (CompCo c c') = CompCo (raiseCo v c) (raiseCo v c')
+raiseCo v (ReflCo t) = ReflCo (raiseT v t)
+raiseCo v (AssumedCo t t') = AssumedCo (raiseT v t) (raiseT v t')
 raiseCo v (SymCo x) = SymCo (raiseCo v x)
+raiseCo v (AppCo f x) = AppCo (raiseCo v f) (raiseCo v x)
+raiseCo v (ArrCo f x) = ArrCo (raiseCo v f) (raiseCo v x)
+raiseCo v (ProdCo f x) = ProdCo (raiseCo v f) (raiseCo v x)
+raiseCo v (ExactRowsCo rs) = ExactRowsCo (map (second (raiseCo v)) rs)
+raiseCo v (RowsCo c rs) = RowsCo (raiseCo v c) (map (second (raiseCo v)) rs)

--- a/src/Syntax/Subst.hs
+++ b/src/Syntax/Subst.hs
@@ -54,14 +54,24 @@ instance Ord (Var p) => Substitutable p (Type p) where
 
 instance Ord (Var p) => Substitutable p (Coercion p) where
   ftv VarCo{} = mempty
-  ftv (ReflCo t t') = ftv t <> ftv t'
-  ftv (CompCo c c') = ftv c <> ftv c'
+  ftv (ReflCo t) = ftv t
+  ftv (AssumedCo t t') = ftv t <> ftv t'
   ftv (SymCo c) = ftv c
+  ftv (AppCo f x) = ftv f <> ftv x
+  ftv (ArrCo f x) = ftv f <> ftv x
+  ftv (ProdCo f x) = ftv f <> ftv x
+  ftv (ExactRowsCo rs) = foldMap (ftv . snd) rs
+  ftv (RowsCo c rs) = ftv c <> foldMap (ftv . snd) rs
 
   apply _ x@VarCo{} = x
-  apply s (ReflCo t t') = ReflCo (apply s t) (apply s t')
-  apply s (CompCo t t') = CompCo (apply s t) (apply s t')
+  apply s (ReflCo t) = ReflCo (apply s t)
+  apply s (AssumedCo t t') = AssumedCo (apply s t) (apply s t')
   apply s (SymCo x) = SymCo (apply s x)
+  apply s (AppCo f x) = AppCo (apply s f) (apply s x)
+  apply s (ArrCo f x) = ArrCo (apply s f) (apply s x)
+  apply s (ProdCo f x) = ProdCo (apply s f) (apply s x)
+  apply s (ExactRowsCo rs) = ExactRowsCo (map (second (apply s)) rs)
+  apply s (RowsCo c rs) = RowsCo (apply s c) (map (second (apply s)) rs)
 
 instance (Ord (Var p), Substitutable p a) => Substitutable p [a] where
   ftv = foldMap ftv

--- a/src/Syntax/Transform.hs
+++ b/src/Syntax/Transform.hs
@@ -36,8 +36,13 @@ transformCoercion
   -> Coercion p -> Coercion p
 transformCoercion fc ft = goC where
   transC (VarCo c) = VarCo c
-  transC (ReflCo l r) = ReflCo (goT l) (goT r)
-  transC (CompCo l r) = CompCo (goC l) (goC r)
+  transC (ReflCo l) = ReflCo (goT l)
+  transC (AssumedCo l r) = AssumedCo (goT l) (goT r)
+  transC (AppCo f x) = AppCo (goC f) (goC x)
+  transC (ArrCo f x) = AppCo (goC f) (goC x)
+  transC (ProdCo f x) = AppCo (goC f) (goC x)
+  transC (ExactRowsCo rs) = ExactRowsCo (map (second goC) rs)
+  transC (RowsCo c rs) = RowsCo (goC c) (map (second goC) rs)
   transC (SymCo c) = SymCo (goC c)
 
   goT = transformType ft . ft

--- a/src/Types/Infer.hs
+++ b/src/Types/Infer.hs
@@ -38,6 +38,8 @@ import Types.Unify
 import Types.Kinds
 
 import Pretty
+import Debug.Trace
+import Text.Show.Pretty (ppShow)
 
 -- Solve for the types of lets in a program
 inferProgram :: MonadGen Int m => Env -> [Toplevel Resolved] -> m (Either TypeError ([Toplevel Typed], Env))
@@ -285,6 +287,7 @@ inferLetTy closeOver vs =
         (x, co, vt) <- case solve cur cs of
           Right (x, co) -> pure (x, co, normType (closeOver (apply x ty)))
           Left e -> throwError (ArisingFrom e (snd blame))
+        -- trace (ppShow x) pure ()
         skolCheck (TvName (fst blame)) (snd blame) vt
         pure (closeOver vt, solveEx x co)
 

--- a/src/Types/Infer.hs
+++ b/src/Types/Infer.hs
@@ -38,8 +38,6 @@ import Types.Unify
 import Types.Kinds
 
 import Pretty
-import Debug.Trace
-import Text.Show.Pretty (ppShow)
 
 -- Solve for the types of lets in a program
 inferProgram :: MonadGen Int m => Env -> [Toplevel Resolved] -> m (Either TypeError ([Toplevel Typed], Env))

--- a/src/Types/Infer.hs
+++ b/src/Types/Infer.hs
@@ -371,10 +371,9 @@ solveEx ss cs = transformExprTyped go' go (normType . apply ss) where
   go' x = x
 
   go :: Coercion Typed -> Coercion Typed
-  go x@(VarCo v) = Map.findWithDefault x v cs
-  go (ReflCo t t') = ReflCo (apply ss t) (apply ss t')
-  go (CompCo c c') = CompCo (go c) (go c')
-  go (SymCo x) = SymCo (go x)
+  go t@(VarCo x) = Map.findWithDefault t x cs
+  go x = x
+
 
 consFst :: Functor m => a -> m ([a], b) -> m ([a], b)
 consFst = fmap . first . (:)

--- a/src/Types/Unify.hs
+++ b/src/Types/Unify.hs
@@ -75,7 +75,7 @@ unify (TySkol t@(Skolem sv _ _ _)) b = do
         if canWe
            then bind sv b
            else throwError $ SkolBinding t b
-unify b (TySkol t) = unify (TySkol t) b
+unify b (TySkol t) = SymCo <$> unify (TySkol t) b
 
 unify (TyVar a) b = bind a b
 unify a (TyVar b) = SymCo <$> bind b a
@@ -84,7 +84,9 @@ unify (TyWithConstraints cs a) t = do
   traverse_ (uncurry unify) cs
   unify a t
 
-unify t x@TyWithConstraints{} = SymCo <$> unify x t
+unify t (TyWithConstraints cs ty) = do
+  traverse_ (uncurry unify) cs
+  unify t ty
 
 unify (TyArr a b) (TyArr a' b') = ArrCo <$> unify a a' <*> unify b b'
 unify (TyApp a b) (TyApp a' b') = AppCo <$> unify a a' <*> unify b b'


### PR DESCRIPTION
Except for the η-expansion associated with subsumption constraints, coercions now represent the steps that the solver took to make two types equal.