### PR TITLE
Fix type annotations for mutually recursive bindings

### DIFF
--- a/compiler/Main.hs
+++ b/compiler/Main.hs
@@ -57,7 +57,7 @@ compile (file:files) = runGen $ do
   files' <- foldlM go file' files
   case files' of
     Right (prg, _, _, env) -> do
-      lower <- runReaderT (lowerProg prg) env
+      lower <- runReaderT (lowerProg prg) mempty
       optm <- optimise lower
       pure (CSuccess (prg, lower, tagOccursVar optm, env))
 


### PR DESCRIPTION
In any top-level binding, we keep track of what types the variables "should" be and what they actually are. If there's a discrepancy, we attempt to unify and generate the appopriate type applications.

I don't know if this implementation is sane (it isn't) or correct, but it seems to work on my rudimentary examples. It might be possible to simplify the fold a little bit, by hoisting out the continuation - I'm open to opinions.