### PR TITLE
Add support for an "open in" construct

### DIFF
--- a/src/Parser.y
+++ b/src/Parser.y
@@ -76,6 +76,7 @@ import Syntax
   qident   { Token (TcIdentifierQual _ _) _ }
   qopid    { Token (TcOpIdentQual _ _) _ }
   qconid   { Token (TcConIdentQual _ _) _ }
+  qdotid   { Token (TcDotQual _) _ }
   access   { Token (TcAccess _) _ }
   tyvar    { Token (TcTyVar _) _ }
   hole     { Token (TcHole _) _ }
@@ -83,7 +84,7 @@ import Syntax
   float    { Token (TcFloat _) _ }
   string   { Token (TcString  _) _ }
 
-%expect 71
+%expect 74
 
 %%
 
@@ -100,9 +101,10 @@ Top :: { Toplevel Parsed }
     | type ident ListE(TyVar) '=' '|' List1(Ctor, '|') { TypeDecl (getName $2) (map getL $3) $6 }
 
 
-    | module Con '=' begin Tops end            { Module (getL $2) $5 }
+    | module qconid '=' begin Tops end         { Module (getName $2) $5 }
+    | module conid '=' begin Tops end          { Module (getName $2) $5 }
+    | module conid '=' Con                     { Open (getL $4) (Just (getIdent $2)) }
     | open Con                                 { Open (getL $2) Nothing }
-    | open Con as conid                        { Open (getL $2) (Just (getIdent $4)) }
 
 Ctor :: { Constructor Parsed }
      : conid                                   { withPos1 $1 $ UnitCon (getName $1) }
@@ -134,7 +136,8 @@ Atom :: { Expr Parsed }
      | hole                                   { withPos1 $1 (Hole (Name (getHole $1))) }
      | '_'                                    { withPos1 $1 (Hole (Name (T.singleton '_'))) }
      | begin List1(Expr, ';') end             { withPos2 $1 $3 $ Begin $2 }
-     | '(' ')'                                { withPos2 $1 $2 $ Literal LiUnit  }
+     | qdotid Atom                            { withPos2 $1 $2 $ OpenIn (getName $1) $2 }
+     | '(' ')'                                { withPos2 $1 $2 $ Literal LiUnit }
      | '(' Section ')'                        { $2 }
      | '(' List1(NullSection, ',') ')'        { withPos2 $1 $3 $ tupleExpr $2 }
      | '{' Rows('=', Expr) '}'                { withPos2 $1 $3 $ Record $2 }
@@ -321,6 +324,7 @@ getName (Token (TcConIdent x) _)          = Name x
 getName (Token (TcIdentifierQual ms x) _) = foldl (flip InModule) (Name x) ms
 getName (Token (TcOpIdentQual ms x) _)    = foldl (flip InModule) (Name x) ms
 getName (Token (TcConIdentQual ms x) _)   = foldl (flip InModule) (Name x) ms
+getName (Token (TcDotQual ms) _)          = foldl (flip InModule) (Name (last ms)) (init ms)
 getName (Token (TcTyVar x) _)             = Name x
 
 getHole   (Token (TcHole x) _)       = x

--- a/src/Parser.y
+++ b/src/Parser.y
@@ -84,7 +84,7 @@ import Syntax
   float    { Token (TcFloat _) _ }
   string   { Token (TcString  _) _ }
 
-%expect 74
+%expect 79
 
 %%
 
@@ -123,6 +123,7 @@ ExprApp :: { Expr Parsed }
 Expr0 :: { Expr Parsed }
       : fun ListE1(ArgP) '->' Expr             { foldr (\x y -> withPos2 x $4 $ Fun x y) $4 $2 }
       | let BindGroup in Expr                  { withPos2 $1 $4 $ Let (reverse $2) $4 }
+      | let open Con in Expr                   { withPos2 $1 $5 $ OpenIn (getL $3) $5 }
       | if Expr then Expr else Expr            { withPos2 $1 $6 $ If $2 $4 $6 }
       | match List1(Expr, ',') with ListE1(Arm)
         { withPos2 $1 $3 $ Match (completeTuple Tuple $2) $4 }

--- a/src/Parser/Token.hs
+++ b/src/Parser/Token.hs
@@ -53,6 +53,7 @@ data TokenClass
   | TcIdentifierQual [Text] Text
   | TcOpIdentQual [Text] Text
   | TcConIdentQual [Text] Text
+  | TcDotQual [Text]
   | TcTyVar Text
   | TcAccess Text
   | TcHole Text
@@ -113,6 +114,7 @@ instance Show TokenClass where
   show (TcIdentifierQual ms t) = concatMap (\m -> unpack m ++ ['.']) (reverse ms) ++ unpack t
   show (TcConIdentQual ms t) = concatMap (\m -> unpack m ++ ['.']) (reverse ms) ++ unpack t
   show (TcOpIdentQual ms t) = "`" ++ concatMap (\m -> unpack m ++ ['.']) (reverse ms) ++ unpack t ++ "`"
+  show (TcDotQual ms) = concatMap (\m -> unpack m ++ ['.']) ms
   show (TcTyVar t) = '\'':unpack t
   show (TcAccess t) = '.':unpack t
   show (TcHole t) = unpack t

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -99,6 +99,9 @@ data Expr p
   | Tuple [Expr p] (Ann p)
   | TupleSection [Maybe (Expr p)] (Ann p)
 
+  -- Module
+  | OpenIn (Var p) (Expr p) (Ann p)
+
   | ExprWrapper (Wrapper p) (Expr p) (Ann p)
 
 deriving instance (Eq (Var p), Eq (Ann p)) => Eq (Expr p)

--- a/src/Syntax/Desugar.hs
+++ b/src/Syntax/Desugar.hs
@@ -67,6 +67,8 @@ desugarProgram = traverse statement where
          $ foldf (\v e -> Fun v e a) args
          $ Tuple tuple a
 
+  expr (OpenIn _ e _) = expr e
+
   buildTuple :: MonadGen Int m
              => Ann Resolved
              -> Maybe (Expr Resolved)

--- a/src/Syntax/Pretty.hs
+++ b/src/Syntax/Pretty.hs
@@ -67,6 +67,9 @@ instance (Pretty (Var p)) => Pretty (Expr p) where
 
   pretty (Tuple es _) = parens (hsep (punctuate comma (map pretty es)))
   pretty (TupleSection es _) = parens (hsep (punctuate comma (map (maybe (string "") pretty) es)))
+
+  pretty (OpenIn v e _) = pretty v <+> string "." <+> parens (pretty e)
+
   pretty (ExprWrapper wrap ex _) = go wrap ex where
     go (TypeLam v t) ex = keyword "fun" <+> braces (pretty v <+> colon <+> pretty t) <> dot <+> pretty ex
     go (Cast c) ex = parens (pretty ex <+> soperator (string "|>") <+> pretty c)

--- a/src/Syntax/Raise.hs
+++ b/src/Syntax/Raise.hs
@@ -34,6 +34,7 @@ raiseE vR aR =
       Tuple es a -> Tuple (map eR es) (aR a)
       Ascription e t a -> Ascription (eR e) (raiseT vR t) (aR a)
       TupleSection es a -> TupleSection (fmap eR <$> es) (aR a)
+      OpenIn n e a -> OpenIn (vR n) (eR e) (aR a)
       ExprWrapper w e a -> ExprWrapper (raiseWrapper vR w) (eR e) (aR a)
 
 raiseWrapper :: (Var p -> Var p') -> Wrapper p -> Wrapper p'

--- a/src/Syntax/Transform.hs
+++ b/src/Syntax/Transform.hs
@@ -82,6 +82,8 @@ transformExpr fe = goE where
   transE (Tuple es a) = Tuple (map goE es) a
   transE (TupleSection es a) = TupleSection (map (goE<$>) es) a
 
+  transE (OpenIn n e a) = OpenIn n (goE e) a
+
   transE (ExprWrapper w e a) = ExprWrapper w (goE e) a
 
   goE = transE . fe
@@ -117,6 +119,8 @@ transformExprTyped fe fc ft = goE where
 
   transE (Tuple es a) = Tuple (map goE es) (goA a)
   transE (TupleSection es a) = TupleSection (map (goE<$>) es) (goA a)
+
+  transE (OpenIn n e a) = OpenIn n (goE e) (goA a)
 
   transE (ExprWrapper w e a) = ExprWrapper (goW w) (goE e) (goA a)
 
@@ -177,4 +181,7 @@ correct ty (Parens e a) = Parens e (fst a, ty)
 
 correct ty (Tuple es a) = Tuple es (fst a, ty)
 correct ty (TupleSection es a) = TupleSection es (fst a, ty)
+
+correct ty (OpenIn n e a) = OpenIn n e (fst a, ty)
+
 correct ty (ExprWrapper w e a) = ExprWrapper w e (fst a, ty)


### PR DESCRIPTION
This evaluates the expression within the scope of a module. Some examples:


```ml
module X = begin
  let a = 1
  and b = 2
end ;;

let main = begin
  X.a; (* As before, just a module index *)
  X.(a, b) (* Constructs a tuple of (X.a, X.b) *)
  X.(a + b) (* Evaluates X.a + X.b *)
  X.{ a = a } (* Evaluates { a = X.a } *)
end
```

This also changes the syntax for "import as" from `open X as Y` to `module Y = X`.