### PR TITLE
Add join points to Core

### DIFF
--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -124,6 +124,7 @@ library amulet
                      , Core.Optimise.Inline
                      , Core.Optimise.Sinking
                      , Core.Optimise.Newtype
+                     , Core.Optimise.Joinify
                      , Core.Optimise.DeadCode
                      -- Backend
                      , Backend.Lua

--- a/compiler/Test/Core/Lint.hs
+++ b/compiler/Test/Core/Lint.hs
@@ -119,5 +119,6 @@ files =
   , "pipe.ml"
   , "polymorphic-recursion.ml"
   -- , "skolems.ml"
+  , "stream.ml"
   , "unsound/reference.ml"
   ]

--- a/examples/stream.ml
+++ b/examples/stream.ml
@@ -1,0 +1,73 @@
+external val io_write : string -> unit = "io.write" ;;
+external val print : string -> unit = "print" ;;
+external val to_string : 'a -> string = "tostring" ;;
+external val rem : int -> int -> int = "function(x, y) return x % y end" ;;
+
+type step 's 'a =
+  | Skip of 's
+  | Yield of 'a * 's
+  | Done ;;
+
+type stream 'a =
+  | Stream : forall 's. ('s -> step 's 'a) * 's -> stream 'a ;;
+
+let take len (Stream (f, start)) =
+  let go (i, st) =
+    if i <= len then
+      match f st with
+      | Done -> Done
+      | Skip s -> Skip (i + 1, s)
+      | Yield (a, s) -> Yield (a, i + 1, s)
+    else
+      Done
+  in Stream (go, 1, start) ;;
+
+let filter p (Stream (f, start)) =
+  let go st =
+    match f st with
+    | Done -> Done
+    | Skip s -> Skip s
+    | Yield (a, s) -> if p a then
+      Yield (a, s)
+    else
+      Skip s
+  in Stream (go, start) ;;
+
+let range (start, limit) =
+  let go n =
+    if n > limit then
+      Done
+    else
+      Yield (n, n + 1)
+  in Stream (go, start) ;;
+
+let fold_stream f z (Stream (stream, start)) =
+  let go ac st =
+    match stream st with
+    | Yield (a, st) -> go (f a ac) st
+    | Skip st -> go ac st
+    | Done -> ac
+  in go z start ;;
+
+let dump_stream e (Stream (f, start)) =
+  let go st =
+    match f st with
+    | Skip st -> go st
+    | Yield (a, st) -> begin
+      io_write ("'" ^ e a ^ "', ");
+      go st
+    end
+    | Done -> print "]"
+  in begin
+    io_write "[";
+    go start
+  end ;;
+
+let (|>) x f = f x ;;
+
+let main = range (1, 10000000)
+    |> take 100
+    |> filter (fun x -> rem x 2 == 0)
+    |> fold_stream (+) 0
+    |> to_string
+    |> print

--- a/src/Backend/Compile.hs
+++ b/src/Backend/Compile.hs
@@ -244,7 +244,7 @@ compileTerm (Extend tbl exs) = do
 
         compileRow (f, _, e) es = (:es) . LuaAssign [LuaIndex (LuaRef new) (LuaString f)] . pure <$> compileAtom e
 
-compileTerm (Let (One (x, _, e)) body)
+compileTerm (Let ValueBind (One (x, _, e)) body)
   | usedWhen x == Once && not (isMultiMatch e) = do
       -- If we've got a let binding which is only used once then push it onto the stack
       e' <- compileTerm e
@@ -276,7 +276,7 @@ compileTerm (Let (One (x, _, e)) body)
         asStmt (LuaCall f e) = [ LuaCallS f e ]
         asStmt _ = []
 
-compileTerm (Let (Many bs) body) = do
+compileTerm (Let ValueBind (Many bs) body) = do
   -- Otherwise predeclare all variables and emit the bindings
   bs' <- traverse ((LuaName<$>) . pushScope . fst3) bs
   flushStmt [ LuaLocal bs' [] ]

--- a/src/Core/Free.hs
+++ b/src/Core/Free.hs
@@ -77,18 +77,18 @@ tagFreeTerm ann var = tagTerm where
         fv = fvf <> fvx
     in (fv, AnnApp (ann an fv) f' x')
 
-  tagTerm (AnnLet an (One (v, ty, e)) r) =
+  tagTerm (AnnLet an k (One (v, ty, e)) r) =
     let (fve, e') = tagTerm e
         (fvr, r') = tagTerm r
         fv = fve <> VarSet.delete (toVar v) fvr
-    in (fv, AnnLet (ann an fv) (One (var' v fvr, conv ty, e')) r')
-  tagTerm (AnnLet an (Many vs) r) =
+     in (fv, AnnLet (ann an fv) k (One (var' v fvr, conv ty, e')) r')
+  tagTerm (AnnLet an k (Many vs) r) =
     let (fvvs, vs') = unzip (map (tagTerm . thd3) vs)
         (fvr, r') = tagTerm r
 
         fvs = mconcat (fvr : fvvs)
         fv = foldr (VarSet.delete . toVar . fst3) fvs vs
-    in (fv, AnnLet (ann an fv) (Many (zipWith (\(v, ty, _) e -> (var' v fvs, conv ty, e)) vs vs')) r')
+     in (fv, AnnLet (ann an fv) k (Many (zipWith (\(v, ty, _) e -> (var' v fvs, conv ty, e)) vs vs')) r')
 
   tagTerm (AnnMatch an t bs) =
     let (fvt, t') = tagAtom t

--- a/src/Core/Lint.hs
+++ b/src/Core/Lint.hs
@@ -21,7 +21,7 @@ import Data.List
 import Core.Optimise
 import Core.Builtin
 import Core.Types
-import Core.Arity (lamArity')
+import Core.Arity (lamArity, lamArity')
 import Pretty hiding ((<>))
 
 data CoreError a
@@ -36,6 +36,9 @@ data CoreError a
 data Scope a = Scope { vars :: VarMap.Map (Type a, VarInfo)
                      , types :: VarMap.Map VarInfo
                      , tyVars :: VarSet.Set }
+  deriving (Show)
+
+data Context = Vanilla | Tail
   deriving (Show)
 
 emptyScope :: IsVar a => Scope a
@@ -110,7 +113,7 @@ checkStmt s t@(StmtLet vs:xs) = do
     -- And the type is well formed
     checkType s ty
     -- And the definition matches the expected type
-    ty' <- checkTerm s' e
+    ty' <- checkTerm Tail s' e
     if ty `apart` ty' then throwError (TypeMismatch ty ty') else pure ()
 
   checkStmt s' xs
@@ -150,7 +153,7 @@ checkAtom s l@(Lam (TermArgument a ty) bod) = do
     unless (varInfo a == ValueVar) (throwError (InfoIllegal a ValueVar (varInfo a)))
     checkType s ty
 
-  bty <- checkTerm (s { vars = insertVar a ty (vars s) }) bod `withContext` l
+  bty <- checkTerm Tail (s { vars = insertVar a ty (vars s) }) bod `withContext` l
   pure (ForallTy Irrelevant ty bty)
 checkAtom s l@(Lam (TypeArgument a ty) bod) = do
   tryContext l $ do
@@ -158,21 +161,82 @@ checkAtom s l@(Lam (TypeArgument a ty) bod) = do
     unless (varInfo a == TypeVar) (throwError (InfoIllegal a TypeVar (varInfo a)))
     checkType s ty
 
-  bty <- checkTerm (s { tyVars = VarSet.insert (toVar a) (tyVars s) }) bod `withContext` l
+  bty <- checkTerm Tail (s { tyVars = VarSet.insert (toVar a) (tyVars s) }) bod `withContext` l
   pure (ForallTy (Relevant a) ty bty)
 
+checkJoinAtom :: (IsVar a, MonadError (CoreError a) m, MonadWriter [CoreError a] m)
+              => Scope a
+              -> Atom a
+              -> m (Type a)
+checkJoinAtom s a@(Ref v ty) =
+  case VarMap.lookup (toVar v) (vars s) of
+    Nothing -> throwError (NoSuchVar v)
+    Just (ty', inf')
+      -- Ensure the types line up
+      | ty `apart` ty' -> throwError (TypeMismatch ty' ty) `withContext` a
+      -- Ensure the variable info lines up, and it's a valid variable
+      | inf' /= varInfo v -> throwError (InfoMismatch v inf' (varInfo v))
+      | not (isJoinInfo inf') -> throwError (InfoIllegal v (JoinVar (-1)) inf')
+      | otherwise -> pure ty
+checkJoinAtom _ _ = throwError (InfoIllegal unknownVar (JoinVar (-1)) ValueVar)
+
+
 checkTerm :: forall a m. (IsVar a, MonadError (CoreError a) m, MonadWriter [CoreError a] m)
-         => Scope a
-         -> Term a
-         -> m (Type a)
-checkTerm s (Atom a) = checkAtom s a
-checkTerm s (App f x) = do
+          => Context
+          ->  Scope a
+          -> Term a
+          -> m (Type a)
+
+-- If we're in a tail position, verify the join point has arity 1
+checkTerm Tail s (App fa@(Ref f _) x)
+  | CoVar _ _ (JoinVar a) <- toVar f = do
+      -- The arity in a tail position must be 1
+      unless (a == 1) (throwError (InfoMismatch f (JoinVar 1) (JoinVar a)))
+
+      f' <- checkJoinAtom s fa
+      x' <- checkAtom s x
+      case f' of
+        ForallTy Irrelevant a r | a `uni` x' -> pure r
+        _ -> throwError (TypeMismatch (ForallTy Irrelevant x' unknownTyvar) f')
+checkTerm c s t@(Let JoinBind (One (v, ty, e)) r)
+  | CoVar _ _ (JoinVar a) <- toVar v
+  = do
+      tryContext t $ do
+        checkType s ty
+
+        (ty', ea) <- case e of
+          Atom at@(Ref f _)
+            | CoVar _ _ (JoinVar a') <- toVar f -> (,a') <$> checkJoinAtom s at
+          Atom at@Lam{} -> (,lamArity at) <$> checkAtom s at
+          App fa@(Ref f _) x
+            | CoVar _ _ (JoinVar a') <- toVar f -> do
+                f' <- checkJoinAtom s fa
+                x' <- checkAtom s x
+                case f' of
+                  ForallTy Irrelevant a r | a `uni` x' -> pure (r, a' - 1)
+                  _ -> throwError (TypeMismatch (ForallTy Irrelevant x' unknownTyvar) f')
+          TyApp fa@(Ref f _) x
+            | CoVar _ _ (JoinVar a') <- toVar f -> do
+                f' <- checkJoinAtom s fa
+                checkType s x `withContext` t
+                case f' of
+                  ForallTy (Relevant a) _ ty -> pure (substituteInType (VarMap.singleton (toVar a) x) ty, a' - 1)
+                  _ -> throwError (TypeMismatch (ForallTy (Relevant unknownVar) unknownTyvar unknownTyvar) f') `withContext` t
+          _ -> throwError (InfoIllegal v (JoinVar (-1)) (JoinVar a))
+
+        unless (a == ea) (throwError (InfoMismatch v (JoinVar ea) (JoinVar a)))
+        if ty `apart` ty' then throwError (TypeMismatch ty ty') else pure ()
+
+      checkTerm c (s { vars = insertVar v ty (vars s) }) r
+
+checkTerm _ s (Atom a) = checkAtom s a
+checkTerm _ s (App f x) = do
   f' <- checkAtom s f
   x' <- checkAtom s x
   case f' of
     ForallTy Irrelevant a r | a `uni` x' -> pure r
     _ -> throwError (TypeMismatch (ForallTy Irrelevant x' unknownTyvar) f')
-checkTerm s t@(Let k (One (v, ty, e)) r) = do
+checkTerm c s t@(Let k (One (v, ty, e)) r) = do
   tryContext t $ do
     -- Ensure type is valid and we're declaring the appropriate variable
     case k of
@@ -183,11 +247,11 @@ checkTerm s t@(Let k (One (v, ty, e)) r) = do
                | otherwise -> throwError (InfoIllegal v (JoinVar (lamArity' e)) (varInfo v))
     checkType s ty
 
-    ty' <- checkTerm s e
+    ty' <- checkTerm Vanilla s e
     if ty `apart` ty' then throwError (TypeMismatch ty ty') else pure ()
 
-  checkTerm (s { vars = insertVar v ty (vars s) }) r
-checkTerm s t@(Let k (Many vs) r) = do
+  checkTerm c (s { vars = insertVar v ty (vars s) }) r
+checkTerm c s t@(Let k (Many vs) r) = do
   let s' = s { vars = foldr (\(v, t, _) -> insertVar v t) (vars s) vs }
   for_ vs $ \(v, ty, e) -> tryContext t $ do
     -- Ensure type is valid and we're declaring a value
@@ -199,12 +263,12 @@ checkTerm s t@(Let k (Many vs) r) = do
                | otherwise -> throwError (InfoIllegal v (JoinVar (lamArity' e)) (varInfo v))
     checkType s ty
 
-    ty' <- checkTerm s' e
+    ty' <- checkTerm Vanilla s' e
     if ty `apart` ty' then throwError (TypeMismatch ty ty') else pure ()
 
-  checkTerm s' r
+  checkTerm c s' r
 
-checkTerm s t@(Match e bs) = flip withContext t $ do
+checkTerm c s t@(Match e bs) = flip withContext t $ do
   tye <- checkAtom s e
   (ty:tys) <- for bs $ \Arm { _armPtrn = p, _armTy = ty, _armBody = r, _armVars = vs } -> do
     if vs /= patternVars p
@@ -214,7 +278,7 @@ checkTerm s t@(Match e bs) = flip withContext t $ do
     pVars <- checkPattern ty p `withContext` p
     if ty `apart` tye
     then throwError (TypeMismatch ty tye)
-    else checkTerm (s { vars = VarMap.union pVars (vars s), tyVars = tyVars s <> foldMap (freeInTy . fst) pVars }) r
+    else checkTerm c (s { vars = VarMap.union pVars (vars s), tyVars = tyVars s <> foldMap (freeInTy . fst) pVars }) r
 
   -- Ensure all types are consistent
   foldrM (\ty ty' -> if ty `apart` ty'
@@ -276,7 +340,7 @@ checkTerm s t@(Match e bs) = flip withContext t $ do
       inst (ForallTy (Relevant _) _ t) = inst t
       inst t = t
 
-checkTerm s t@(Extend f fs) = do
+checkTerm _ s t@(Extend f fs) = do
   tyf' <- checkAtom s f
   for_ fs $ \(_, ty, v) -> tryContext t $ do
     ty' <- checkAtom s v
@@ -287,14 +351,14 @@ checkTerm s t@(Extend f fs) = do
     RowsTy f' fs' -> pure $ RowsTy f' $ nubBy (on (==) fst) $ map (\(f, ty, _) -> (f, ty)) fs ++ fs'
     _ -> throwError (TypeMismatch (ExactRowsTy []) tyf') `withContext` t
 
-checkTerm s t@(TyApp f x) = do
+checkTerm _ s t@(TyApp f x) = do
   f' <- checkAtom s f
   checkType s x `withContext` t
   case f' of
     ForallTy (Relevant a) _ ty -> pure (substituteInType (VarMap.singleton (toVar a) x) ty)
     _ -> throwError (TypeMismatch (ForallTy (Relevant unknownVar) unknownTyvar unknownTyvar) f') `withContext` t
 
-checkTerm s t@(Cast x co) = do
+checkTerm _ s t@(Cast x co) = do
   ty <- checkAtom s x
 
   (from, to) <- checkCo co

--- a/src/Core/Occurrence.hs
+++ b/src/Core/Occurrence.hs
@@ -127,18 +127,18 @@ tagOccurTerm ann var = tagTerm where
         fv = fvf # fvx
     in (fv, AnnApp (ann an fv) f' x')
 
-  tagTerm (AnnLet an (One (v, ty, e)) r) =
+  tagTerm (AnnLet an k (One (v, ty, e)) r) =
     let (fve, e') = tagTerm e
         (fvr, r') = tagTerm r
         fv = fve # VarMap.delete (toVar v) fvr
-    in (fv, AnnLet (ann an fv) (One (var' v fvr, conv ty, e')) r')
-  tagTerm (AnnLet an (Many vs) r) =
+     in (fv, AnnLet (ann an fv) k (One (var' v fvr, conv ty, e')) r')
+  tagTerm (AnnLet an k (Many vs) r) =
     let (fvvs, vs') = unzip (map (tagTerm . thd3) vs)
         (fvr, r') = tagTerm r
 
         fvs = occConcat (fvr : fvvs)
         fv = foldr (VarMap.delete . toVar . fst3) fvs vs
-    in (fv, AnnLet (ann an fv) (Many (zipWith (\(v, ty, _) e -> (var' v fvs, conv ty, e)) vs vs')) r')
+     in (fv, AnnLet (ann an fv) k (Many (zipWith (\(v, ty, _) e -> (var' v fvs, conv ty, e)) vs vs')) r')
 
   tagTerm (AnnMatch an t bs) =
     let (fvt, t') = tagAtom t

--- a/src/Core/Optimise/Inline.hs
+++ b/src/Core/Optimise/Inline.hs
@@ -59,7 +59,10 @@ inlineVariablePass = transS (InlineScope mempty mempty) where
   transT s (Let k (One var) body) = do
     var' <- third3A (transT s) var
     body' <- transT (extendVar var s) body
-    pure (Let k (One var') body')
+    pure $ case var' of
+      (v, ty, Let ek ev eb) -> 
+        Let ek ev (Let k (One (v, ty, eb)) body)
+      _ -> Let k (One var') body'
   transT s (Let k (Many vars) body) = do
     vars' <- traverse (third3A (transT s)) vars
     body' <- transT (extendVars vars' s) body

--- a/src/Core/Optimise/Inline.hs
+++ b/src/Core/Optimise/Inline.hs
@@ -42,8 +42,8 @@ inlineVariablePass = transS (InlineScope mempty mempty) where
     case f' of
       Ref r _
         | Just (Lam (TermArgument v t) b, score) <- VarMap.lookup (toVar r) (scores s)
-        , score <= limit -> refresh$ Let (One (v, t, Atom a')) b
-      Lam (TermArgument v t) b -> pure $ Let (One (v, t, Atom a')) b
+        , score <= limit -> refresh $ Let ValueBind (One (v, t, Atom a')) b
+      Lam (TermArgument v t) b -> pure $ Let ValueBind (One (v, t, Atom a')) b
       _ -> pure (App f' a')
   transT s (Cast f t) = flip Cast t <$> transA s f
   transT s (TyApp f t) = do
@@ -56,14 +56,14 @@ inlineVariablePass = transS (InlineScope mempty mempty) where
       f' -> pure $ TyApp f' t
   transT s (Extend t rs) = Extend <$> transA s t
                                   <*> traverse (third3A (transA s)) rs
-  transT s (Let (One var) body) = do
+  transT s (Let k (One var) body) = do
     var' <- third3A (transT s) var
     body' <- transT (extendVar var s) body
-    pure (Let (One var') body')
-  transT s (Let (Many vars) body) = do
+    pure (Let k (One var') body')
+  transT s (Let k (Many vars) body) = do
     vars' <- traverse (third3A (transT s)) vars
     body' <- transT (extendVars vars' s) body
-    pure (Let (Many vars') body')
+    pure (Let k (Many vars') body')
   transT s (Match test branches) = Match <$> transA s test
                                          <*> traverse (armBody %%~ transT s) branches
 
@@ -88,8 +88,8 @@ scoreAtom s (Lam TermArgument{} b) = 1 + scoreTerm s b
 scoreTerm :: IsVar a => InlineScope a -> Term a  -> Int
 scoreTerm s (Atom a) = scoreAtom s a
 scoreTerm s (App f x) = scoreAtom s f + scoreAtom s x + 2
-scoreTerm s (Let (One v) e) = scoreTerm s (thd3 v) + scoreTerm s e
-scoreTerm s (Let (Many vs) e) = sum (map (scoreTerm s . thd3) vs) + scoreTerm s e
+scoreTerm s (Let _ (One v) e) = scoreTerm s (thd3 v) + scoreTerm s e
+scoreTerm s (Let _ (Many vs) e) = sum (map (scoreTerm s . thd3) vs) + scoreTerm s e
 scoreTerm s (Match e bs) = scoreAtom s e + sum (map (scoreTerm s . view armBody) bs)
 scoreTerm s (Extend e rs) = scoreAtom s e + sum (map (scoreAtom s . thd3) rs)
 scoreTerm s (TyApp t _) = scoreAtom s t

--- a/src/Core/Optimise/Joinify.hs
+++ b/src/Core/Optimise/Joinify.hs
@@ -4,54 +4,227 @@ module Core.Optimise.Joinify where
 import Control.Monad.Gen
 import Control.Lens
 
+import qualified Data.VarMap as VarMap
+import qualified Data.VarSet as VarSet
 import Data.Triple
 
 import Core.Optimise
 import Core.Types
+import Core.Arity (lamArity')
+
+import Debug.Trace
+import Pretty
+
+data JoinConversion = Preserve | JoinOne Int | JoinMany [Int]
+  deriving (Show, Eq)
 
 matchJoinPass :: forall m a. (MonadGen Int m, IsVar a) => [Stmt a] -> m [Stmt a]
 matchJoinPass = traverse transS where
-  transS (StmtLet vars) = StmtLet <$> traverse (third3A (transT False)) vars
+  transS (StmtLet vars) = StmtLet <$> traverse (third3A (transT mempty False . gatherJoinPass)) vars
   transS s = pure s
 
-  transA t@Ref{} = pure t
-  transA t@Lit{} = pure t
-  transA (Lam arg b) = Lam arg <$> transT True b
+  transA :: VarMap.Map Int -> AnnAtom JoinConversion a -> m (Atom a)
+  transA s (Ref v t) =
+    let v'@(CoVar i name _) = toVar v
+    in pure (maybe (Ref v t) (flip Ref t . fromVar . CoVar i name . JoinVar) (VarMap.lookup v' s))
+  transA _ (Lit l) = pure (Lit l)
+  transA s (Lam arg b) = Lam arg <$> transT s True b
 
-  transT _ (Atom a) = Atom <$> transA a
-  transT _ (App f a) = App <$> transA f <*> transA a
-  transT _ (TyApp f t) = flip TyApp t <$> transA f
-  transT _ (Cast f t) = flip Cast t <$> transA f
+  transT :: VarMap.Map Int -> Bool -> AnnTerm JoinConversion a -> m (Term a)
+  transT s _ (AnnAtom _ a) = Atom <$> transA s a
+  transT s _ (AnnApp _ f a) = App <$> transA s f <*> transA s a
+  transT s _ (AnnTyApp _ f t) = flip TyApp t <$> transA s f
+  transT s _ (AnnCast _ f t) = flip Cast t <$> transA s f
 
-  transT True (Let ValueBind (One (name, nameTy, Match sc as)) cont) = do
+  -- Lambda to join point promotion
+  transT s True (AnnLet (JoinOne a) ValueBind (One (v, ty, e)) r) = do
+    let v' = toVar v
+        s' = VarMap.insert v' a s
+    e' <- transT s False e
+    Let JoinBind (One (fromVar (set covarInfo (JoinVar a) v'), ty, e')) <$> transT s' True r
+  transT s True (AnnLet (JoinMany as) ValueBind (Many vs) r) = do
+    let s' = foldr (uncurry (VarMap.insert . toVar . fst3)) s (zip vs as)
+    es' <- traverse (transT s' False . thd3) vs
+    let vs' = zipWith3 (\(v, ty, _) a e -> (fromVar (set covarInfo (JoinVar a) (toVar v)), ty, e)) vs as es'
+    Let JoinBind (Many vs') <$> transT s' True r
+
+  -- Intermediate usage of lambda to join point promotion
+  transT s True (AnnLet _ ValueBind (One (v, ty, AnnApp _ f@(Ref fv _) x)) r)
+    | Just fa <- VarMap.lookup (toVar fv) s = do
+    let a = fa - 1
+        v' = toVar v
+        s' = VarMap.insert v' a s
+    f' <- transA s f
+    x' <- transA s x
+    Let JoinBind (One (fromVar (set covarInfo (JoinVar a) v'), ty, App f' x')) <$> transT s' True r
+  transT s True (AnnLet _ ValueBind (One (v, ty, AnnTyApp _ f@(Ref fv _) x)) r)
+    | Just fa <- VarMap.lookup (toVar fv) s = do
+    let a = fa - 1
+        v' = toVar v
+        s' = VarMap.insert v' a s
+    f' <- transA s f
+    Let JoinBind (One (fromVar (set covarInfo (JoinVar a) v'), ty, TyApp f' x)) <$> transT s' True r
+
+  -- Match commuting conversion
+  transT s True (AnnLet _ ValueBind (One (name, nameTy, AnnMatch _ sc as)) cont) = do
     join <- fromVar <$> fresh (JoinVar 1)
     let Just res = approximateType cont
         joinTy = ForallTy Irrelevant nameTy res
 
-        shoveJoinArm :: Atom a -> Type a -> Arm a -> m (Arm a)
+        shoveJoinArm :: AnnAtom JoinConversion a -> Type a -> AnnArm JoinConversion a -> m (AnnArm JoinConversion a)
         shoveJoinArm j ty = armBody %%~ shoveJoin j ty
 
-        shoveJoin :: Atom a -> Type a -> Term a -> m (Term a)
-        shoveJoin j ty (Let k bind body) = Let k bind <$> shoveJoin j ty body
-        shoveJoin j ty (Match t bs) = Match t <$> traverse (shoveJoinArm j ty) bs
-        shoveJoin j _  (Atom a) = pure (App j a)
+        shoveJoin :: AnnAtom JoinConversion a -> Type a -> AnnTerm JoinConversion a -> m (AnnTerm JoinConversion a)
+        shoveJoin j ty (AnnLet b k bind body) = AnnLet b k bind <$> shoveJoin j ty body
+        shoveJoin j ty (AnnMatch b t bs) = AnnMatch b t <$> traverse (shoveJoinArm j ty) bs
+        shoveJoin j _  (AnnAtom b a) = pure (AnnApp b j a)
 
         shoveJoin j (ForallTy Irrelevant ty _) ex = do
           var <- fromVar <$> fresh ValueVar
-          pure (Let ValueBind (One (var, ty, ex)) (App j (Ref var ty)))
+          pure (AnnLet Preserve ValueBind (One (var, ty, ex)) (AnnApp Preserve j (Ref var ty)))
         shoveJoin j t ex = error ("What: shoveJoin " ++ show j ++ " " ++ show t ++ " " ++ show ex)
 
     as <- traverse (shoveJoinArm (Ref join joinTy) joinTy) as
-    transT True (Let JoinBind (One (join, joinTy, Atom (Lam (TermArgument name nameTy) cont)))
-                 (Match sc as))
+    transT s True (AnnLet Preserve JoinBind (One (join, joinTy, AnnAtom Preserve (Lam (TermArgument name nameTy) cont)))
+                   (AnnMatch Preserve sc as))
 
-  transT c (Let k (One var) r) = do
-    var' <- third3A (transT False) var
-    Let k (One var') <$> transT c r
+  transT s c (AnnLet _ k (One var) r) = do
+    var' <- third3A (transT s False) var
+    Let k (One var') <$> transT s c r
 
-  transT c (Let k (Many vs) r) = do
-    vs' <- traverse (third3A (transT False)) vs
-    Let k (Many vs') <$> transT c r
+  transT s c (AnnLet _ k (Many vs) r) = do
+    vs' <- traverse (third3A (transT s False)) vs
+    Let k (Many vs') <$> transT s c r
 
-  transT _ (Extend t rs) = Extend <$> transA t <*> traverse (third3A transA) rs
-  transT c (Match t bs) = Match <$> transA t <*> traverse (armBody %%~ transT c) bs
+  transT s _ (AnnExtend _ t rs) = Extend <$> transA s t <*> traverse (third3A (transA s)) rs
+  transT s c (AnnMatch _ t bs) = Match <$> transA s t <*> traverse (armBody %%~ transT s c) bs
+
+gatherJoinPass :: forall a. IsVar a => Term a -> AnnTerm JoinConversion a
+gatherJoinPass = snd . goT mempty True mempty where
+  goA _ a (Ref v ty) =
+    (if toVar v `VarMap.member` a then traceShow (string "Deleting" <+> pretty v) else id)
+    (VarMap.delete (toVar v) a, Ref v ty)
+  goA u a (Lam arg body) = Lam arg <$> goT (VarMap.foldrWithKey (\a _ -> VarSet.insert a) u a) True a body
+  goA _ a (Lit l) = (a, Lit l)
+
+  -- Tail calls of candiates
+  goT u True a (App (Ref f fty) x)
+    | Just n <- VarMap.lookup (toVar f) a
+    , toVar f `VarSet.notMember` u
+    = let a'= if n > 1 then VarMap.insert (toVar f) 1 a else a
+      in AnnApp Preserve (Ref f fty) <$> goA u a' x
+  goT u True a (TyApp (Ref f fty) x)
+    | Just n <- VarMap.lookup (toVar f) a
+    , toVar f `VarSet.notMember` u
+    = let a'= if n > 1 then VarMap.insert (toVar f) 1 a else a
+      in (a', AnnTyApp Preserve (Ref f fty) x)
+
+  -- If we're visiting an application of a candidate which is used in a tail position
+  goT u True a (Let ValueBind (One (v, vty, App (Ref f fty) x)) r)
+    | Just n <- VarMap.lookup (toVar f) a, n > 1
+    , toVar f `VarSet.notMember` u
+    = let (a', x') = goA u a x
+          -- We insert our entry into the set with an arity of one less
+          -- and visit child nodes with it
+          ca = VarMap.insert (toVar v) (n - 1) a'
+          (ca', r') = goT u True ca r
+          -- We can extract the lookup from our new set and update as appropriate
+          varr = maybe 0 (+1) (VarMap.lookup (toVar v) ca')
+          a'' = VarMap.delete (toVar v) $
+                case VarMap.lookup (toVar f) ca' of
+                  Just i | varr == 0 -> VarMap.delete (toVar f) ca'
+                         | i > varr -> VarMap.insert (toVar f) varr ca'
+                  _ -> ca'
+      in traceShow (string "Mapping" <+> pretty v <+> string (show varr) <+> string "=" <+> pretty f <+> string " => " <+> string (show (VarMap.lookup (toVar f) a'')))
+        (a'', AnnLet Preserve ValueBind (One (v, vty, AnnApp Preserve (Ref f fty) x')) r')
+  goT u True a (Let ValueBind (One (v, vty, TyApp (Ref f fty) x)) r)
+    | Just n <- VarMap.lookup (toVar f) a, n > 1
+    , toVar f `VarSet.notMember` u
+    = let -- We insert our entry into the set with an arity of one less
+          -- and visit child nodes with it
+          ca = VarMap.insert (toVar v) (n - 1) a
+          (ca', r') = goT u True ca r
+          -- We can extract the lookup from our new set and update as appropriate
+          varr = maybe 0 (+1) (VarMap.lookup (toVar v) ca')
+          a' = VarMap.delete (toVar v) $
+                case VarMap.lookup (toVar f) ca' of
+                  Just i | varr == 0 -> VarMap.delete (toVar f) ca'
+                         | i > varr -> VarMap.insert (toVar f) varr ca'
+                  _ -> ca'
+      in traceShow (string "Mapping" <+> pretty v <+> string (show varr) <+> string "=" <+> pretty f <+> string " => " <+> string (show (VarMap.lookup (toVar f) a')))
+         (a', AnnLet Preserve ValueBind (One (v, vty, AnnTyApp Preserve (Ref f fty) x)) r')
+
+  -- Single definitions in the tail position which are lambdas are candidates
+  goT u True a (Let ValueBind (One (v, ty, e)) r) | isLam e =
+    let (a', e') = goT u False a e
+        -- And visit the remaining nodes with this definition's arity
+        ca = VarMap.insert (toVar v) (lamArity' e) a'
+        (ca', r') = goT u True ca r
+        -- If we've still got something in scope, then we can convert it.
+        arr = case VarMap.lookup (toVar v) ca' of
+                Nothing -> Preserve
+                Just x -> traceShow (string "Promoting" <+> pretty v, x) $ JoinOne x
+    in ( VarMap.delete (toVar v) ca'
+       , AnnLet arr ValueBind (One (v, ty, e')) r')
+
+  -- Recursive definitions in the tail position which are lambdas are candidates
+  goT u True a (Let ValueBind (Many vs) r) | all (isLam . thd3) vs =
+    let ca = foldr (\(v, _, e) -> VarMap.insert (toVar v) (lamArity' e)) a vs
+        (ca', vs') = foldr (go3 (goLam . flip (goT u))) (ca, []) vs
+        (ca'', r') = goT u True ca' r
+        -- If we've still got something in scope, then we can convert it.
+        arr = case traverse (flip VarMap.lookup ca'' . toVar . fst3) vs of
+                Nothing -> Preserve
+                Just x -> JoinMany x
+    in ( foldr (VarMap.delete . toVar . fst3) ca'' vs
+       ,  AnnLet arr ValueBind (Many vs') r')
+
+  -- Normal "fallback" visitors
+  -- Honestly, this is just a MonadState (VarMap.Map Int), but it's a faff.
+  goT u _ a (Atom at) = AnnAtom Preserve <$> goA u a at
+  goT u _ a (App f x) =
+    let (a', f') = goA u a f
+        (a'', x') = goA u a' x
+    in (a'', AnnApp Preserve f' x')
+  goT u _ a (TyApp f x) =
+    let (a', f') = goA u a f
+    in (a', AnnTyApp Preserve f' x)
+  goT u c a (Let k (One (v, ty, e)) r) =
+    -- TODO: Join points should not push upvalues - strip the lambda first
+    let (a', e') = goT u False a e
+        (a'', r') = goT u c a' r
+    in (a'', AnnLet Preserve k (One (v, ty, e')) r')
+  goT u c a (Let k (Many vs) r) =
+    -- TODO: Join points should not push upvalues - strip the lambda first
+    let (a', vs') = foldr (go3 (goT u False)) (a, []) vs
+        (a'', r') = goT u c a' r
+    in (a'', AnnLet Preserve k (Many vs') r')
+  goT u c a (Match t ps) =
+    let (a', t') = goA u a t
+        (a'', ps') = foldr goP (a', []) ps
+    in (a'', AnnMatch Preserve t' ps')
+    where
+      goP ar (a, ps) =
+        let (a', e') = goT u c a (view armBody ar)
+        in (a', set armBody e' ar:ps)
+  goT u _ a (Extend f fs) =
+    let (a', f') = goA u a f
+        (a'', fs') = foldr (go3 (goA u)) (a', []) fs
+    in (a'', AnnExtend Preserve f' fs')
+  goT u _ a (Cast e c) =
+    let (a', e') = goA u a e
+    in (a', AnnCast Preserve e' c)
+
+
+  go3 g (f, ty, e) (a, fs) =
+    let (a', e') = g a e
+    in (a', (f, ty, e'):fs)
+
+  isLam (Atom Lam{}) = True
+  isLam _ = False
+
+  goLam :: Functor f => (Bool -> Term a -> f (AnnTerm JoinConversion a)) -> Term a -> f (AnnTerm JoinConversion a)
+  goLam f a@(Atom Lam{}) = goImpl a
+    where goImpl (Atom (Lam arg t)) = AnnAtom Preserve . Lam arg <$> goImpl t
+          goImpl t = f True t
+  goLam f t = f False t

--- a/src/Core/Optimise/Joinify.hs
+++ b/src/Core/Optimise/Joinify.hs
@@ -11,19 +11,19 @@ import Core.Types
 
 matchJoinPass :: forall m a. (MonadGen Int m, IsVar a) => [Stmt a] -> m [Stmt a]
 matchJoinPass = traverse transS where
-  transS (StmtLet vars) = StmtLet <$> traverse (third3A transT) vars
+  transS (StmtLet vars) = StmtLet <$> traverse (third3A (transT False)) vars
   transS s = pure s
 
   transA t@Ref{} = pure t
   transA t@Lit{} = pure t
-  transA (Lam arg b) = Lam arg <$> transT b
+  transA (Lam arg b) = Lam arg <$> transT True b
 
-  transT (Atom a) = Atom <$> transA a
-  transT (App f a) = App <$> transA f <*> transA a
-  transT (TyApp f t) = flip TyApp t <$> transA f
-  transT (Cast f t) = flip Cast t <$> transA f
+  transT _ (Atom a) = Atom <$> transA a
+  transT _ (App f a) = App <$> transA f <*> transA a
+  transT _ (TyApp f t) = flip TyApp t <$> transA f
+  transT _ (Cast f t) = flip Cast t <$> transA f
 
-  transT (Let ValueBind (One (name, nameTy, Match sc as)) cont) = do
+  transT True (Let ValueBind (One (name, nameTy, Match sc as)) cont) = do
     join <- fromVar <$> fresh (JoinVar 1)
     let Just res = approximateType cont
         joinTy = ForallTy Irrelevant nameTy res
@@ -42,16 +42,16 @@ matchJoinPass = traverse transS where
         shoveJoin j t ex = error ("What: shoveJoin " ++ show j ++ " " ++ show t ++ " " ++ show ex)
 
     as <- traverse (shoveJoinArm (Ref join joinTy) joinTy) as
-    transT (Let JoinBind (One (join, joinTy, Atom (Lam (TermArgument name nameTy) cont)))
-              (Match sc as))
+    transT True (Let JoinBind (One (join, joinTy, Atom (Lam (TermArgument name nameTy) cont)))
+                 (Match sc as))
 
-  transT (Let k (One var) r) = do
-    var' <- third3A transT var
-    Let k (One var') <$> transT r
+  transT c (Let k (One var) r) = do
+    var' <- third3A (transT False) var
+    Let k (One var') <$> transT c r
 
-  transT (Let k (Many vs) r) = do
-    vs' <- traverse (third3A transT) vs
-    Let k (Many vs') <$> transT r
+  transT c (Let k (Many vs) r) = do
+    vs' <- traverse (third3A (transT False)) vs
+    Let k (Many vs') <$> transT c r
 
-  transT (Extend t rs) = Extend <$> transA t <*> traverse (third3A transA) rs
-  transT (Match t bs) = Match <$> transA t <*> traverse (armBody %%~ transT) bs
+  transT _ (Extend t rs) = Extend <$> transA t <*> traverse (third3A transA) rs
+  transT c (Match t bs) = Match <$> transA t <*> traverse (armBody %%~ transT c) bs

--- a/src/Core/Optimise/Joinify.hs
+++ b/src/Core/Optimise/Joinify.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE FlexibleContexts, ScopedTypeVariables #-}
+module Core.Optimise.Joinify where
+
+import Control.Monad.Gen
+import Control.Lens
+
+import Data.Triple
+
+import Core.Optimise
+import Core.Types
+
+matchJoinPass :: forall m a. (MonadGen Int m, IsVar a) => [Stmt a] -> m [Stmt a]
+matchJoinPass = traverse transS where
+  transS (StmtLet vars) = StmtLet <$> traverse (third3A transT) vars
+  transS s = pure s
+
+  transA t@Ref{} = pure t
+  transA t@Lit{} = pure t
+  transA (Lam arg b) = Lam arg <$> transT b
+
+  transT (Atom a) = Atom <$> transA a
+  transT (App f a) = App <$> transA f <*> transA a
+  transT (TyApp f t) = flip TyApp t <$> transA f
+  transT (Cast f t) = flip Cast t <$> transA f
+
+  transT (Let ValueBind (One (name, nameTy, Match sc as)) cont) = do
+    join <- fromVar <$> fresh (JoinVar 1)
+    let Just res = approximateType cont
+        joinTy = ForallTy Irrelevant nameTy res
+
+        shoveJoinArm :: Atom a -> Type a -> Arm a -> m (Arm a)
+        shoveJoinArm j ty = armBody %%~ shoveJoin j ty
+
+        shoveJoin :: Atom a -> Type a -> Term a -> m (Term a)
+        shoveJoin j ty (Let k bind body) = Let k bind <$> shoveJoin j ty body
+        shoveJoin j ty (Match t bs) = Match t <$> traverse (shoveJoinArm j ty) bs
+        shoveJoin j _  (Atom a) = pure (App j a)
+
+        shoveJoin j (ForallTy Irrelevant ty _) ex = do
+          var <- fromVar <$> fresh ValueVar
+          pure (Let ValueBind (One (var, ty, ex)) (App j (Ref var ty)))
+        shoveJoin j t ex = error ("What: shoveJoin " ++ show j ++ " " ++ show t ++ " " ++ show ex)
+
+    as <- traverse (shoveJoinArm (Ref join joinTy) joinTy) as
+    transT (Let JoinBind (One (join, joinTy, Atom (Lam (TermArgument name nameTy) cont)))
+              (Match sc as))
+
+  transT (Let k (One var) r) = do
+    var' <- third3A transT var
+    Let k (One var') <$> transT r
+
+  transT (Let k (Many vs) r) = do
+    vs' <- traverse (third3A transT) vs
+    Let k (Many vs') <$> transT r
+
+  transT (Extend t rs) = Extend <$> transA t <*> traverse (third3A transA) rs
+  transT (Match t bs) = Match <$> transA t <*> traverse (armBody %%~ transT) bs

--- a/src/Core/Optimise/Newtype.hs
+++ b/src/Core/Optimise/Newtype.hs
@@ -67,10 +67,10 @@ goBinding m = traverse (third3A goTerm) where
   goTerm :: Term a -> Gen Int (Term a)
   goTerm (Atom x) = Atom <$> goAtom x
   goTerm (App f x) = App <$> goAtom f <*> goAtom x
-  goTerm (Let (Many vs) e) = Let . Many <$> goBinding m vs <*> goTerm e
-  goTerm (Let (One (v, t, e)) b) = do
+  goTerm (Let k (Many vs) e) = Let k . Many <$> goBinding m vs <*> goTerm e
+  goTerm (Let k (One (v, t, e)) b) = do
     e' <- goTerm e
-    Let (One (v, t, e')) <$> goTerm b
+    Let k (One (v, t, e')) <$> goTerm b
   goTerm (Extend a as) = Extend <$> goAtom a <*> traverse (third3A goAtom) as
   goTerm (TyApp f t) = TyApp <$> goAtom f <*> pure t
   goTerm (Cast f t) = Cast <$> goAtom f <*> pure t
@@ -80,7 +80,7 @@ goBinding m = traverse (third3A goTerm) where
       let Just (_, castCodomain) = relates phi
       bd' <- goTerm (Match (Ref (fromVar var) castCodomain) [Arm { _armPtrn = p, _armTy = castCodomain
                                                                  , _armBody = bd, _armVars = vs, _armTyvars = tvs }])
-      pure $ Let (One (fromVar var, castCodomain, Cast a phi)) bd'
+      pure $ Let ValueBind (One (fromVar var, castCodomain, Cast a phi)) bd'
     _ -> Match <$> goAtom a <*> traverse (armBody %%~ goTerm) x
 
   goAtom (Lam arg e) = Lam arg <$> goTerm e

--- a/src/Core/Optimise/Sinking.hs
+++ b/src/Core/Optimise/Sinking.hs
@@ -10,6 +10,7 @@ import Core.Optimise
 import qualified Core.Arity as A
 
 data Sinkable a = Sinkable { sBind  :: (a, Type a, Term a)
+                           , sKind :: BindingKind
                            , sFree  :: VarSet.Set
                            , sBound :: VarSet.Set }
   deriving (Show)
@@ -64,11 +65,12 @@ sinkTerm s (AnnAtom _ a) = flushBinds (sinkable s) (Atom (sinkAtom (nullBinds s)
 sinkTerm s (AnnApp _ f x) = flushBinds (sinkable s) (App (sinkAtom s' f) (sinkAtom s' x))
   where s' = nullBinds s
 
-sinkTerm s (AnnLet _ (One b@(v, ty, e)) r)
+sinkTerm s (AnnLet _ k (One b@(v, ty, e)) r)
   -- If we're pure, add it to the sink set
   | A.isPure (arity s) e
   = let e' = sinkTerm (nullBinds s) e
         s' = s { sinkable = Sinkable { sBind = (v, ty, e')
+                                     , sKind = k
                                      , sBound = VarSet.singleton (toVar v)
                                      , sFree = extractAnn e } : sinkable s
                , arity = A.extendPureFuns (arity s) [b] }
@@ -80,14 +82,14 @@ sinkTerm s (AnnLet _ (One b@(v, ty, e)) r)
         a' = A.extendPureFuns (arity s) [b]
         e' = sinkTerm (s { sinkable = es, arity = a' }) e
         r' = sinkTerm (s { sinkable = rs, arity = a' }) r
-    in flushBinds fs (Let (One (v, ty, e')) r')
+     in flushBinds fs (Let k (One (v, ty, e')) r')
 
-sinkTerm s (AnnLet _ (Many vs) r) =
+sinkTerm s (AnnLet _ k (Many vs) r) =
   let (fs, rs:vss) = partitionBinds (sinkable s) (extractAnn r : map (extractAnn . thd3) vs)
       a' = A.extendPureFuns (arity s) vs
       vs' = zipWith (\fv -> third3 (sinkTerm (s { sinkable = fv, arity = a' }))) vss vs
       r'  = sinkTerm (s { sinkable = rs, arity = a' }) r
-  in flushBinds fs (Let (Many vs') r')
+   in flushBinds fs (Let k (Many vs') r')
 
 sinkTerm s (AnnMatch _ t bs) =
   let (fs, ts:bss) = partitionBinds (sinkable s) (freeInAtom t : map (extractAnn . view armBody) bs)
@@ -103,7 +105,7 @@ sinkTerm s (AnnCast _ f co) = flushBinds (sinkable s) (Cast (sinkAtom (nullBinds
 
 flushBinds :: [Sinkable a] -> Term a -> Term a
 flushBinds [] t = t
-flushBinds (si@Sinkable{}:xs) t = flushBinds xs (Let (One (sBind si)) t)
+flushBinds (si@Sinkable{}:xs) t = flushBinds xs (Let (sKind si) (One (sBind si)) t)
 
 nullBinds :: SinkState a -> SinkState a
 nullBinds s = s { sinkable = [] }

--- a/src/Core/Simplify.hs
+++ b/src/Core/Simplify.hs
@@ -18,11 +18,14 @@ import Core.Lint
 import Control.Monad.Gen
 import Control.Monad
 
+import Pretty
+import System.IO.Unsafe
+
 lintPasses :: Bool
 lintPasses = True
 
-optmOnce :: [Stmt CoVar] -> Gen Int [Stmt CoVar]
-optmOnce = passes where
+optmOnce :: Int -> [Stmt CoVar] -> Gen Int [Stmt CoVar]
+optmOnce k = passes where
   passes = foldr1 (>=>) $ linted
            [ pure
 
@@ -41,12 +44,21 @@ optmOnce = passes where
 
   linted
     | lintPasses
-    = intersperse (pure . (runLint =<< checkStmt emptyScope))
+    -- = intersperse (pure . (runLint =<< checkStmt emptyScope))
+    = zipWith (\i f x -> (runLint =<< checkStmt emptyScope) . dump i <$> f x) ([0..] :: [Int])
     | otherwise = id
+
+  {-# NOINLINE dump #-}
+  dump i x = unsafePerformIO $ do
+    let ok = case runLintOK (checkStmt emptyScope x) of
+               Left _ -> "er"
+               Right _ -> "ok"
+    writeFile ("dump_" ++ show k ++"_" ++ show i ++ "_" ++ ok ++ ".ml") (show $ pretty x)
+    pure x
 
 optimise :: [Stmt CoVar] -> Gen Int [Stmt CoVar]
 optimise = go 25 where
-  go :: Integer -> [Stmt CoVar] -> Gen Int [Stmt CoVar]
+  go :: Int -> [Stmt CoVar] -> Gen Int [Stmt CoVar]
   go k sts
-    | k > 0 = go (k - 1) . (runLint =<< checkStmt emptyScope) =<< optmOnce sts
+    | k > 0 = go (k - 1) =<< optmOnce k sts
     | otherwise = pure sts

--- a/src/Core/Simplify.hs
+++ b/src/Core/Simplify.hs
@@ -6,9 +6,10 @@ import Data.List
 
 -- import Core.Optimise.Newtype
 import Core.Optimise.DeadCode
+import Core.Optimise.Sinking
+import Core.Optimise.Joinify
 import Core.Optimise.Inline
 import Core.Optimise.Reduce
-import Core.Optimise.Sinking
 import Core.Optimise
 
 import Core.Free
@@ -29,6 +30,7 @@ optmOnce = passes where
            , inlineVariablePass
 
            , pure . deadCodePass
+           , matchJoinPass
            -- , killNewtypePass
 
            , pure . sinkingPass . tagFreeSet

--- a/src/Core/Types.hs
+++ b/src/Core/Types.hs
@@ -46,7 +46,7 @@ approximateType (Cast _ phi) = snd <$> relates phi
 approximateType (App f _) = do
   ForallTy _ _ d <- approximateAtomType f
   pure d
-approximateType (Let _ e) = approximateType e
+approximateType (Let _ _ e) = approximateType e
 approximateType (Match _ xs) = case xs of
   (x:_) -> approximateType (x ^. armBody)
   [] -> error "impossible approximateType empty match"

--- a/src/Core/Var.hs
+++ b/src/Core/Var.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveGeneric, DeriveDataTypeable, TemplateHaskell #-}
+{-# LANGUAGE DeriveGeneric, DeriveDataTypeable, TemplateHaskell, OverloadedStrings #-}
 
 module Core.Var where
 
@@ -35,7 +35,15 @@ makePrisms ''VarInfo
 
 
 instance Pretty CoVar where
-  pretty (CoVar i v _) = text v <> scomment (string "#" <> string (show i))
+  pretty (CoVar i v k) = text v <> scomment (string "#" <> pretty k <> string (show i))
+
+instance Pretty VarInfo where
+  pretty ValueVar = text "v"
+  pretty DataConVar = text "D"
+  pretty TypeConVar = text "t"
+  pretty TypeVar = text "'t"
+  pretty CastVar = text "c"
+  pretty (JoinVar i) = text "j" <> brackets (string (show i))
 
 class (Eq a, Ord a, Pretty a, Show a) => IsVar a where
   toVar :: a -> CoVar

--- a/src/Core/Var.hs
+++ b/src/Core/Var.hs
@@ -27,6 +27,7 @@ data VarInfo
   | TypeConVar
   | TypeVar
   | CastVar
+  | JoinVar {-# UNPACK #-} !Int
   deriving (Eq, Show, Ord, Generic, Data)
 
 makeLenses ''CoVar
@@ -51,6 +52,7 @@ isValueInfo, isTypeInfo :: VarInfo -> Bool
 
 isValueInfo ValueVar = True
 isValueInfo DataConVar = True
+isValueInfo (JoinVar _) = True
 isValueInfo _ = False
 
 isTypeInfo TypeConVar = True

--- a/src/Core/Var.hs
+++ b/src/Core/Var.hs
@@ -48,12 +48,14 @@ instance IsVar CoVar where
   toVar = id
   fromVar = id
 
-isValueInfo, isTypeInfo :: VarInfo -> Bool
+isValueInfo, isJoinInfo, isTypeInfo :: VarInfo -> Bool
 
 isValueInfo ValueVar = True
 isValueInfo DataConVar = True
-isValueInfo (JoinVar _) = True
 isValueInfo _ = False
+
+isJoinInfo (JoinVar _) = True
+isJoinInfo _ = False
 
 isTypeInfo TypeConVar = True
 isTypeInfo DataConVar = True

--- a/src/Data/VarMap.hs
+++ b/src/Data/VarMap.hs
@@ -3,8 +3,8 @@ module Data.VarMap
   ( Map
   , fromList, toList
   , lookup, member, findWithDefault
-  , insert, delete
-  , map, singleton, union, unionSemigroup
+  , insert, insertWith, delete
+  , map, singleton, union, unionSemigroup, unionOn
   , foldrWithKey
   , (<>), mempty
   ) where
@@ -27,6 +27,9 @@ newtype Map a
 
 insert :: CoVar -> a -> Map a -> Map a
 insert (CoVar x _ _) v (Map k) = Map (Map.insert x v k)
+
+insertWith :: (a -> a -> a) -> CoVar -> a -> Map a -> Map a
+insertWith f (CoVar x _ _) v (Map k) = Map (Map.insertWith f x v k)
 
 delete :: CoVar -> Map a -> Map a
 delete (CoVar x _ _) (Map k) = Map (Map.delete x k)
@@ -56,7 +59,10 @@ singleton :: CoVar -> a ->  Map a
 singleton (CoVar x _ _) v = coerce (Map.singleton x v)
 
 unionSemigroup :: Semigroup a => Map a -> Map a -> Map a
-unionSemigroup (Map l) (Map r) = Map (Map.merge Map.preserveMissing Map.preserveMissing (Map.zipWithMatched (const (<>))) l r)
+unionSemigroup  = unionOn (<>)
+
+unionOn :: (a -> a -> a) -> Map a -> Map a -> Map a
+unionOn f (Map l) (Map r) = Map (Map.merge Map.preserveMissing Map.preserveMissing (Map.zipWithMatched (const f)) l r)
 
 foldrWithKey :: (CoVar -> a -> b -> b) -> b -> Map a -> b
 foldrWithKey f b (Map m) = Map.foldrWithKey (f . create) b m


### PR DESCRIPTION
I'm mostly creating this so I can get feedback on how they've been added to Core, before cracking on with other features.

Progress:
 - [x] Add join points to core.
 - Conversion of various forms to join points:
   - [x] Match commuting conversion
   - [ ] Tail-recursive functions
 - Correctness:
   - [ ] Non type-checking core lint which verifies join points are well used and defined.
   - [ ] Ensure optimisations preserve join points
 - [ ] Emit join points in the backend, handling most of the common cases
   
(again)