### PR TITLE
Use a specialised variable type for core

### DIFF
--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -109,6 +109,7 @@ library amulet
                      , Data.Position
                      , Data.Spanned
                      -- Core
+                     , Core.Var
                      , Core.Core
                      , Core.Lint
                      , Core.Free

--- a/compiler/Main.hs
+++ b/compiler/Main.hs
@@ -35,6 +35,7 @@ import Core.Occurrence (OccursVar, tagOccursVar)
 import Core.Simplify (optimise)
 import Core.Lower (runLowerT, lowerProg)
 import Core.Core (Stmt)
+import Core.Var (CoVar)
 
 import Pretty (Pretty(pretty), putDoc, (<+>), colon)
 
@@ -45,12 +46,12 @@ import Parser.Lexer (lexerScan)
 import Errors (reportP, reportR, reportI)
 
 data CompileResult a
-  = CSuccess ([Toplevel Typed], [Stmt (Var Resolved)], [Stmt a], Env)
+  = CSuccess ([Toplevel Typed], [Stmt CoVar], [Stmt a], Env)
   | CParse   String Span
   | CResolve ResolveError
   | CInfer   TypeError
 
-compile :: [(SourceName, T.Text)] -> CompileResult (OccursVar (Var Resolved))
+compile :: [(SourceName, T.Text)] -> CompileResult (OccursVar CoVar)
 compile [] = error "Cannot compile empty input"
 compile (file:files) = runGen $ do
   file' <- go (Right ([], RS.builtinScope, RS.emptyModules, builtinsEnv)) file
@@ -98,7 +99,7 @@ compileFromTo fs emit =
     CResolve e -> putStrLn "Resolution error" >> reportR e fs
     CInfer e -> putStrLn "Type error" >> reportI e fs
 
-test :: [(FilePath, T.Text)] -> IO (Maybe ([Stmt (Var Resolved)], Env))
+test :: [(FilePath, T.Text)] -> IO (Maybe ([Stmt CoVar], Env))
 test fs = do
   putStrLn "\x1b[1;32m(* Program: *)\x1b[0m"
   case compile fs of
@@ -127,7 +128,7 @@ testLexer fs = for_ fs $ \(name, file) ->
     POK _ toks -> print (map (\(Token t _) -> t) toks)
     PFailed msg _ -> print msg
 
-testTc :: [(FilePath, T.Text)] -> IO (Maybe ([Stmt (Var Resolved)], Env))
+testTc :: [(FilePath, T.Text)] -> IO (Maybe ([Stmt CoVar], Env))
 testTc fs = do
   putStrLn "\x1b[1;32m(* Program: *)\x1b[0m"
   case compile fs of

--- a/compiler/Test/Core/Lint.hs
+++ b/compiler/Test/Core/Lint.hs
@@ -23,12 +23,12 @@ import Syntax.Resolve (ResolveError, resolveProgram)
 import qualified Syntax.Resolve.Scope as RS
 import Syntax.Resolve.Toplevel (extractToplevels)
 import Syntax.Desugar (desugarProgram)
-import Syntax (Var, Resolved)
 
 import Core.Lower (runLowerT, lowerProg)
 import Core.Core (Stmt)
 import Core.Simplify
 import Core.Lint
+import Core.Var
 
 import Pretty (pretty, render)
 
@@ -39,7 +39,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 data CompileResult
-  = CSuccess [Stmt (Var Resolved)]
+  = CSuccess [Stmt CoVar]
   | CParse   String Span
   | CResolve ResolveError
   | CInfer   TypeError
@@ -78,7 +78,7 @@ compile (file:files) = do
     go x _ = pure x
 
 
-testLint :: ([Stmt (Var Resolved)] -> Gen Int [Stmt (Var Resolved)]) -> String -> Assertion
+testLint :: ([Stmt CoVar] -> Gen Int [Stmt CoVar]) -> String -> Assertion
 testLint f file = do
   contents <- T.readFile ("examples/" ++ file)
   runGen $ do

--- a/src/Backend/Compile.hs
+++ b/src/Backend/Compile.hs
@@ -4,7 +4,6 @@ module Backend.Compile
   ( compileProgram
   ) where
 
-import Control.Monad.Infer
 import Control.Monad.State
 import Control.Monad.Cont
 import Control.Arrow
@@ -12,11 +11,13 @@ import Control.Lens hiding (uncons)
 
 import Backend.Lua
 import Core.Occurrence
-import Core.Core
+import Core.Builtin
 import Core.Types
+import Core.Core
+import Core.Var
 
 import Syntax.Types
-import Syntax (Var(..), Resolved)
+import Syntax (Var(..))
 
 import qualified Types.Wellformed as W
 
@@ -35,14 +36,13 @@ import Data.Char
 
 type Returner = LuaExpr -> LuaStmt
 
-data VarScope = VarScope { toLua :: Map.Map (Var Resolved) Text
-                         , fromLua :: Map.Map Text (Var Resolved) }
+data VarScope = VarScope { toLua :: Map.Map CoVar Text
+                         , fromLua :: Map.Map Text CoVar }
   deriving (Show)
 
 pushVar :: IsVar a => a -> VarScope -> (Text, VarScope)
 pushVar v s = escapeVar (toVar v) where
-  escapeVar (TgInternal t) = (t, s)
-  escapeVar v@(TgName name _) =
+  escapeVar v@(CoVar _ name _) =
     case Map.lookup v (toLua s) of
       Just _ -> error "Variable already declared"
       Nothing ->
@@ -66,9 +66,7 @@ pushVar v s = escapeVar (toVar v) where
          Just _ -> pushFirst (Just (maybe 0 (+1) prefix)) esc
 
 getVar :: IsVar a => a -> VarScope -> Text
-getVar v s = case toVar v of
-               TgInternal t -> t
-               v@TgName{} -> fromMaybe (error ("Cannot find " ++ show v)) (Map.lookup v (toLua s))
+getVar v s = fromMaybe (error ("Cannot find " ++ show v)) (Map.lookup (toVar v) (toLua s))
 
 alpha :: [Text]
 alpha = map T.pack ([1..] >>= flip replicateM ['a'..'z'])
@@ -99,7 +97,7 @@ compileProgram ev = LuaDo . flip evalState (VarScope mempty mempty) . compilePro
   compileProg (StmtLet vs:xs) = (++) <$> compileLet (unzip3 vs) <*> compileProg xs
   compileProg (Type _ cs:xs) = (++) <$> traverse compileConstructor cs <*> compileProg xs
   compileProg [] =
-    let main = fmap (toVar . fst) . uncons
+    let main = fmap fst . uncons
              . sortOn key
              . filter isMain
              . namesInScope
@@ -109,8 +107,8 @@ compileProgram ev = LuaDo . flip evalState (VarScope mempty mempty) . compilePro
         key (TgName k _) = k
         key _ = undefined
      in case main ev of
-       Just ref -> do
-         ref' <- gets (getVar ref)
+       Just ref@(TgName n i) -> do
+         ref' <- gets (getVar (CoVar i n ValueVar))
          let go 0 _ = Nothing
              go 1 it = Just (LuaCallS it [])
              go n it = do
@@ -118,7 +116,7 @@ compileProgram ev = LuaDo . flip evalState (VarScope mempty mempty) . compilePro
                pure $ LuaCallS (LuaCall e []) []
              ar = W.arity (ev ^. values . at ref . non undefined)
           in pure (maybeToList (go ar (LuaRef (LuaName ref'))))
-       Nothing -> pure []
+       _ -> pure []
 
   compileConstructor :: (MonadState VarScope m, Occurs a) => (a, Type a) -> m LuaStmt
   compileConstructor (var, ty)
@@ -181,7 +179,7 @@ compileAtom' (Ref v _) | isBinOp v
            [left]
            [LuaReturn (LuaFunction
                         [right]
-                        [LuaReturn (LuaBinOp (LuaRef left) (remapOp' v) (LuaRef right))])],
+                        [LuaReturn (LuaBinOp (LuaRef left) (remapOp v) (LuaRef right))])],
            Nothing)
     where left  = LuaName "l"
           right = LuaName "r"
@@ -215,7 +213,7 @@ compileTerm (App f e) = do
   e' <- compileAtom e
   f' <- compileAtom' f
   pure $ case f' of
-    (LuaCall _ [l], Just (App (Ref v _) _)) | isBinOp v -> LuaBinOp l (remapOp' v) e'
+    (LuaCall _ [l], Just (App (Ref v _) _)) | isBinOp v -> LuaBinOp l (remapOp v) e'
     (fl', _) -> LuaCall fl' [e']
 
 compileTerm (TyApp f _) = compileAtom f
@@ -378,22 +376,24 @@ compileMatch match test ps = ContT $ \next ->  gets (pure . genIf next . snd)
 
         withMatch = map (\(v, b) -> (v, match, b))
 
-ops :: Map.Map Text Text
+ops :: Map.Map CoVar Text
 ops = Map.fromList
-  [ ("+", "+"), ("+.", "+")
-  , ("-", "-"), ("-.", "-")
-  , ("*", "*"), ("*.", "*")
-  , ("/", "/"), ("/.", "/")
-  , ("**", "^"), ("**.", "^")
-  , ("^", "..")
-  , ("<", "<")
-  , (">", ">")
-  , (">=", ">=")
-  , ("<=", "<=")
-  , ("==", "==")
-  , ("<>", "~=")
-  , ("||", "or")
-  , ("&&", "and") ]
+  [ (vOpAdd, "+"),  (vOpAddF, "+")
+  , (vOpSub, "-"),  (vOpSubF, "-")
+  , (vOpMul, "*"),  (vOpMulF, "*")
+  , (vOpDiv, "/"),  (vOpDivF, "/")
+  , (vOpExp, "^"),  (vOpExpF, "^")
+  , (vOpLt,  "<"),  (vOpLtF,  "<")
+  , (vOpGt,  ">"),  (vOpGtF,  "<")
+  , (vOpLe,  "<="), (vOpLeF,  "<=")
+  , (vOpGe,  ">="), (vOpGeF,  ">=")
+
+  , (vOpConcat, "..")
+
+  , (vOpEq, "==")
+  , (vOpNe, "~=")
+  , (vOpOr, "or")
+  , (vOpAnd, "and") ]
 
 chars :: Map.Map Char Text
 chars = Map.fromList
@@ -420,15 +420,11 @@ chars = Map.fromList
   , ('[', "_lbrack")
   , (']', "_rbrack ") ]
 
-isBinOp :: Occurs a => a -> Bool
-isBinOp x | TgInternal v <- toVar x = Map.member v ops
-isBinOp _ = False
+isBinOp :: IsVar a => a -> Bool
+isBinOp v = Map.member (toVar v) ops
 
-remapOp :: Text -> Text
-remapOp x = fromMaybe x (Map.lookup x ops)
-
-remapOp' :: IsVar a => a -> Text
-remapOp' v = let TgInternal v' = toVar v in remapOp v'
+remapOp :: IsVar a => a -> Text
+remapOp v | v'@(CoVar _ n _) <- toVar v = fromMaybe n (Map.lookup v' ops)
 
 isMultiMatch :: Term a -> Bool
 isMultiMatch (Match _ (_:_:_)) = True

--- a/src/Backend/Compile.hs
+++ b/src/Backend/Compile.hs
@@ -26,7 +26,6 @@ import qualified Data.VarSet as VarSet
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import Data.Foldable
-import Data.VarSet (IsVar(..))
 import Data.Triple
 import Data.Maybe (fromMaybe, maybeToList)
 import Data.List (sortOn, partition, uncons)

--- a/src/Core/Arity.hs
+++ b/src/Core/Arity.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Core.Arity
   ( ArityScope
   , emptyScope
@@ -10,29 +9,23 @@ module Core.Arity
 import Control.Lens
 
 import qualified Data.VarMap as VarMap
-import qualified Data.Map as Map
 import Data.VarSet (IsVar(..))
-import Data.Text (Text)
 import Data.Triple
 import Data.Maybe
 
+import Core.Builtin
 import Core.Core
-import Syntax(Var(..))
 
 newtype ArityScope = ArityScope { pureArity :: VarMap.Map Int }
   deriving (Show)
 
 emptyScope :: ArityScope
-emptyScope = ArityScope mempty
+emptyScope = ArityScope opArity
 
 -- Compute the number of arguments which can be passed to a function before
 -- it becomes "impure".
 atomArity :: IsVar a => ArityScope -> AnnAtom b a -> Int
-atomArity s (Ref r _)
-  | TgInternal n <- toVar r
-  = fromMaybe 0 (Map.lookup n opArity)
-  | otherwise
-  = fromMaybe 0 (VarMap.lookup (toVar r) (pureArity s))
+atomArity s (Ref r _) = fromMaybe 0 (VarMap.lookup (toVar r) (pureArity s))
 atomArity s (Lam _ (AnnAtom _ a)) = 1 + atomArity s a
 atomArity _ _ = 0
 
@@ -71,20 +64,22 @@ extendPureCtors s cts = s {
 
 
 -- Various built-in functions with a predetermined arity
-opArity :: Map.Map Text Int
-opArity = Map.fromList
-    [ ("+",  2), ("+.",  2)
-    , ("-",  2), ("-.",  2)
-    , ("*",  2), ("*.",  2)
-    , ("/",  2), ("/.",  2)
-    , ("**", 2), ("**.", 2)
-    , ("^",  2)
-    , ("<",  2)
-    , (">",  2)
-    , (">=", 2)
-    , ("<=", 2)
-    , ("==", 3)
-    , ("<>", 3)
-    , ("||", 2)
-    , ("&&", 2)
+opArity :: VarMap.Map Int
+opArity = VarMap.fromList
+    [ (vOpAdd, 2), (vOpAddF, 2)
+    , (vOpSub, 2), (vOpSubF, 2)
+    , (vOpMul, 2), (vOpMulF, 2)
+    , (vOpDiv, 2), (vOpDivF, 2)
+    , (vOpExp, 2), (vOpExpF, 2)
+    , (vOpLt,  2), (vOpLtF,  2)
+    , (vOpGt,  2), (vOpGtF,  2)
+    , (vOpLe,  2), (vOpLeF,  2)
+    , (vOpGe,  2), (vOpGeF,  2)
+
+    , (vOpConcat,  2)
+
+    , (vOpEq, 3)
+    , (vOpNe, 3)
+    , (vOpOr, 2)
+    , (vOpAnd, 2)
     ]

--- a/src/Core/Arity.hs
+++ b/src/Core/Arity.hs
@@ -9,12 +9,12 @@ module Core.Arity
 import Control.Lens
 
 import qualified Data.VarMap as VarMap
-import Data.VarSet (IsVar(..))
 import Data.Triple
 import Data.Maybe
 
 import Core.Builtin
 import Core.Core
+import Core.Var
 
 newtype ArityScope = ArityScope { pureArity :: VarMap.Map Int }
   deriving (Show)

--- a/src/Core/Builtin.hs
+++ b/src/Core/Builtin.hs
@@ -1,18 +1,17 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Core.Builtin where
 
-import Data.VarSet (IsVar(..))
 import Data.Text ()
 
 import Core.Core
 import Core.Var
 
 vBool, vInt, vString, vFloat, vUnit :: CoVar
-vBool   = CoVar (-1) "bool" TypeVar
-vInt    = CoVar (-2) "int" TypeVar
-vString = CoVar (-3) "string" TypeVar
-vFloat  = CoVar (-4) "float" TypeVar
-vUnit   = CoVar (-5) "unit" TypeVar
+vBool   = CoVar (-1) "bool" TypeConVar
+vInt    = CoVar (-2) "int" TypeConVar
+vString = CoVar (-3) "string" TypeConVar
+vFloat  = CoVar (-4) "float" TypeConVar
+vUnit   = CoVar (-5) "unit" TypeConVar
 
 tyBool, tyInt, tyString, tyFloat, tyUnit :: IsVar a => Type a
 tyBool   = ConTy $ fromVar vBool
@@ -70,8 +69,8 @@ vError :: CoVar
 vError = CoVar (-29) "error" ValueVar
 
 tyvarA, tyvarB :: CoVar
-tyvarA = CoVar (-30) "a" TyvarVar
-tyvarB = CoVar (-31) "b" TyvarVar
+tyvarA = CoVar (-30) "a" TypeVar
+tyvarB = CoVar (-31) "b" TypeVar
 
 builtinVarList :: (IsVar a, IsVar b) => [(a, Type b)]
 builtinVarList = vars where

--- a/src/Core/Core.hs
+++ b/src/Core/Core.hs
@@ -6,11 +6,11 @@ import Pretty
 
 import qualified Data.VarSet as VarSet
 import Data.Function
-import Data.VarSet (IsVar(..))
 import Data.Triple
 import Data.Maybe
 import Data.Text (Text)
 import Data.List
+import Core.Var
 
 import Control.Lens
 
@@ -250,8 +250,8 @@ instance Pretty a => Pretty [Stmt a] where
   pretty = vcat . map pretty
 
 freeInAtom :: IsVar a => AnnAtom b a -> VarSet.Set
-freeInAtom (Ref v _) = VarSet.singleton (VarSet.toVar v)
-freeInAtom (Lam (TermArgument v _) e) = VarSet.delete (VarSet.toVar v) (freeIn e)
+freeInAtom (Ref v _) = VarSet.singleton (toVar v)
+freeInAtom (Lam (TermArgument v _) e) = VarSet.delete (toVar v) (freeIn e)
 freeInAtom (Lam TypeArgument{} e) = freeIn e
 freeInAtom (Lit _) = mempty
 
@@ -259,7 +259,7 @@ freeIn :: IsVar a => AnnTerm b a -> VarSet.Set
 freeIn (AnnAtom _ a) = freeInAtom a
 freeIn (AnnApp _ f x) = freeInAtom f <> freeInAtom x
 freeIn (AnnLet _ (One v) e) = VarSet.difference (freeIn e <> freeIn (thd3 v)) (VarSet.singleton (toVar (fst3 v)))
-freeIn (AnnLet _ (Many vs) e) = VarSet.difference (freeIn e <> foldMap (freeIn . thd3) vs) (VarSet.fromList (map (VarSet.toVar . fst3) vs))
+freeIn (AnnLet _ (Many vs) e) = VarSet.difference (freeIn e <> foldMap (freeIn . thd3) vs) (VarSet.fromList (map (toVar . fst3) vs))
 freeIn (AnnMatch _ e bs) = freeInAtom e <> foldMap freeInBranch bs where
   freeInBranch x = foldr (VarSet.delete . toVar . fst) (freeIn (x ^. armBody)) (x ^. armVars)
 freeIn (AnnExtend _ c rs) = freeInAtom c <> foldMap (freeInAtom . thd3) rs

--- a/src/Core/Free.hs
+++ b/src/Core/Free.hs
@@ -7,9 +7,9 @@ module Core.Free
 import Control.Lens
 
 import Core.Core as C
+import Core.Var
 
 import qualified Data.VarSet as VarSet
-import Data.VarSet (IsVar(..))
 import Data.Triple
 
 freeSet :: IsVar a => [AnnStmt b a] -> VarSet.Set

--- a/src/Core/Lint.hs
+++ b/src/Core/Lint.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE FlexibleContexts, OverloadedStrings, ExistentialQuantification, ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts, ExistentialQuantification, ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings, TupleSections #-}
 module Core.Lint
   ( CoreError
   , runLint, runLintOK, emptyScope
@@ -24,25 +25,43 @@ import Pretty hiding ((<>))
 
 data CoreError a
   = TypeMismatch (Type a) (Type a)
+  | InfoMismatch a VarInfo VarInfo
+  | InfoIllegal a VarInfo VarInfo
   | forall b. Pretty b => ArisingIn (CoreError a) b
   | NoSuchVar a
   | InvalidCoercion (Coercion a)
   | PatternMismatch [(a, Type a)] [(a, Type a)]
 
-data Scope a = Scope { vars :: VarMap.Map (Type a)
-                     , types :: VarSet.Set
+data Scope a = Scope { vars :: VarMap.Map (Type a, VarInfo)
+                     , types :: VarMap.Map VarInfo
                      , tyVars :: VarSet.Set }
   deriving (Show)
 
 emptyScope :: IsVar a => Scope a
-emptyScope = Scope (VarMap.fromList builtinVarList) (VarSet.fromList builtinTyList) mempty
+emptyScope = Scope (VarMap.fromList (map (\(a, b) -> (a, (b, varInfo a))) builtinVarList))
+                   (VarMap.fromList (map (,TypeConVar) builtinTyList))
+                   mempty
+
+insertVar :: IsVar a => a -> Type a -> VarMap.Map (Type a, VarInfo) -> VarMap.Map (Type a, VarInfo)
+insertVar v t = VarMap.insert (toVar v) (t, varInfo v)
+
+insertTy :: IsVar a => a -> VarMap.Map VarInfo -> VarMap.Map VarInfo
+insertTy v = VarMap.insert (toVar v) (varInfo v)
 
 instance Pretty a => Pretty (CoreError a) where
-  pretty (TypeMismatch l r) = text "Expected type" <+> pretty l </> text "     got type" <+> pretty r
-  pretty (ArisingIn e c) = pretty e </> text "arising in " <+> pretty c
-  pretty (NoSuchVar a) = text "No such variable " <+> pretty a
+  pretty (TypeMismatch l r) = text "Expected type" <+> pretty l </>
+                              text "     got type" <+> pretty r
+  pretty (InfoMismatch v l r) = text "Expected var info" <+> string (show l) </>
+                                text "     got var info" <+> string (show r) </>
+                                text "for" <+> pretty v
+  pretty (InfoIllegal v l r) = text "Expected var info like" <+> string (show l) </>
+                               text "          got var info" <+> string (show r) </>
+                               text "for" <+> pretty v
+  pretty (ArisingIn e c) = pretty e </> text "arising in" <+> pretty c
+  pretty (NoSuchVar a) = text "No such variable" <+> pretty a
   pretty (InvalidCoercion a) = text "Illegal coercion" <+> pretty a
-  pretty (PatternMismatch l r) = text "Expected vars" <+> pVs l </> text "     got vars" <+> pVs r
+  pretty (PatternMismatch l r) = text "Expected vars" <+> pVs l </>
+                                 text "     got vars" <+> pVs r
     where pVs = hsep . punctuate comma . map (\(v, ty) -> pretty v <+> colon <+> pretty ty)
 
   prettyList = vsep . map pretty
@@ -73,18 +92,39 @@ checkStmt :: (IsVar a, MonadError (CoreError a) m, MonadWriter [CoreError a] m)
           -> [Stmt a]
           -> m ()
 checkStmt _ [] = pure ()
-checkStmt s (Foreign v ty _:xs) = checkStmt (s { vars = VarMap.insert (toVar v) ty (vars s) }) xs
+checkStmt s t@(Foreign v ty _:xs) = do
+  tryContext t $ do
+    -- Ensure we're declaring a value
+    unless (varInfo v == ValueVar) (throwError (InfoIllegal v ValueVar (varInfo v)))
+    -- And the type is well formed
+    checkType s ty
+
+  checkStmt (s { vars = insertVar v ty (vars s) }) xs
+
 checkStmt s t@(StmtLet vs:xs) = do
-  let s' = s { vars = foldr (\(v, t, _) -> VarMap.insert (toVar v) t) (vars s) vs }
-  for_ vs $ \(_, ty, e) -> tryContext t $ do
+  let s' = s { vars = foldr (\(v, t, _) -> insertVar v t) (vars s) vs }
+  for_ vs $ \(v, ty, e) -> tryContext t $ do
+    -- Ensure we're declaring a value
+    unless (varInfo v == ValueVar) (throwError (InfoIllegal v ValueVar (varInfo v)))
+    -- And the type is well formed
+    checkType s ty
+    -- And the definition matches the expected type
     ty' <- checkTerm s' e
     if ty `apart` ty' then throwError (TypeMismatch ty ty') else pure ()
 
   checkStmt s' xs
 checkStmt s t@(Type v ctors:xs) = do
-  let s' = s { vars = foldr (uncurry (VarMap.insert . toVar)) (vars s) ctors
-             , types = foldr VarSet.insert (types s) (toVar v : map (toVar . fst) ctors)}
-  for_ ctors $ \(_, x) -> checkType s' x `withContext` t
+  tryContext t $ do
+    -- Ensure we're declaring a type
+    unless (varInfo v == TypeConVar) (throwError (InfoIllegal v TypeConVar (varInfo v)))
+
+  let s' = s { vars = foldr (uncurry insertVar) (vars s) ctors
+             , types = foldr insertTy (types s) (toVar v : map (toVar . fst) ctors)}
+  tryContext t $ for_ ctors $ \(v, x) -> do
+     -- Ensure we're declaring a constructor
+    unless (varInfo v == DataConVar) (throwError (InfoIllegal v DataConVar (varInfo v)))
+    -- Ensure the type is well formed
+    checkType s' x
 
   checkStmt s' xs
 
@@ -95,15 +135,28 @@ checkAtom :: (IsVar a, MonadError (CoreError a) m, MonadWriter [CoreError a] m)
 checkAtom s a@(Ref v ty) =
   case VarMap.lookup (toVar v) (vars s) of
     Nothing -> throwError (NoSuchVar v)
-    Just ty' | ty `apart` ty' -> throwError (TypeMismatch ty' ty) `withContext` a
-             | otherwise -> pure ty
+    Just (ty', inf')
+      -- Ensure the types line up
+      | ty `apart` ty' -> throwError (TypeMismatch ty' ty) `withContext` a
+      -- Ensure the variable info lines up, and it's a valid variable
+      | inf' /= varInfo v -> throwError (InfoMismatch v inf'(varInfo v))
+      | not (isValueInfo inf') -> throwError (InfoIllegal v ValueVar inf')
+      | otherwise -> pure ty
 checkAtom _ (Lit l) = pure (litTy l)
 checkAtom s l@(Lam (TermArgument a ty) bod) = do
-  checkType s ty
-  bty <- checkTerm (s { vars = VarMap.insert (toVar a) ty (vars s) }) bod `withContext` l
+  tryContext l $ do
+    -- Ensure type is valid and we're declaring a value
+    unless (varInfo a == ValueVar) (throwError (InfoIllegal a ValueVar (varInfo a)))
+    checkType s ty
+
+  bty <- checkTerm (s { vars = insertVar a ty (vars s) }) bod `withContext` l
   pure (ForallTy Irrelevant ty bty)
 checkAtom s l@(Lam (TypeArgument a ty) bod) = do
-  checkType s ty
+  tryContext l $ do
+    -- Ensure type is valid and we're declaring a tyvar
+    unless (varInfo a == TypeVar) (throwError (InfoIllegal a TypeVar (varInfo a)))
+    checkType s ty
+
   bty <- checkTerm (s { tyVars = VarSet.insert (toVar a) (tyVars s) }) bod `withContext` l
   pure (ForallTy (Relevant a) ty bty)
 
@@ -120,13 +173,21 @@ checkTerm s (App f x) = do
     _ -> throwError (TypeMismatch (ForallTy Irrelevant x' unknownTyvar) f')
 checkTerm s t@(Let (One (v, ty, e)) r) = do
   tryContext t $ do
+    -- Ensure type is valid and we're declaring a value
+    unless (varInfo v == ValueVar) (throwError (InfoIllegal v ValueVar (varInfo v)))
+    checkType s ty
+
     ty' <- checkTerm s e
     if ty `apart` ty' then throwError (TypeMismatch ty ty') else pure ()
 
-  checkTerm (s { vars = VarMap.insert (toVar v) ty (vars s) }) r
+  checkTerm (s { vars = insertVar v ty (vars s) }) r
 checkTerm s t@(Let (Many vs) r) = do
-  let s' = s { vars = foldr (\(v, t, _) -> VarMap.insert (toVar v) t) (vars s) vs }
-  for_ vs $ \(_, ty, e) -> tryContext t $ do
+  let s' = s { vars = foldr (\(v, t, _) -> insertVar v t) (vars s) vs }
+  for_ vs $ \(v, ty, e) -> tryContext t $ do
+    -- Ensure type is valid and we're declaring a value
+    unless (varInfo v == ValueVar) (throwError (InfoIllegal v ValueVar (varInfo v)))
+    checkType s ty
+
     ty' <- checkTerm s' e
     if ty `apart` ty' then throwError (TypeMismatch ty ty') else pure ()
 
@@ -142,17 +203,18 @@ checkTerm s t@(Match e bs) = flip withContext t $ do
     pVars <- checkPattern ty p `withContext` p
     if ty `apart` tye
     then throwError (TypeMismatch ty tye)
-    else checkTerm (s { vars = VarMap.union pVars (vars s), tyVars = tyVars s <> foldMap freeInTy pVars }) r
+    else checkTerm (s { vars = VarMap.union pVars (vars s), tyVars = tyVars s <> foldMap (freeInTy . fst) pVars }) r
 
   -- Ensure all types are consistent
   foldrM (\ty ty' -> if ty `apart` ty'
                      then throwError (TypeMismatch ty ty')
                      else pure ty') ty tys
     where
-      checkPattern :: Type a -> Pattern a -> m (VarMap.Map (Type a))
+      checkPattern :: Type a -> Pattern a -> m (VarMap.Map (Type a, VarInfo))
       checkPattern ty' (Capture a ty)
-        | Just{} <- ty `unify` ty' = pure (VarMap.singleton (toVar a) ty)
-        | otherwise = throwError (TypeMismatch ty ty')
+        | ty `apartOpen` ty' = throwError (TypeMismatch ty ty')
+        | varInfo a /= ValueVar = throwError (InfoIllegal a ValueVar (varInfo a))
+        | otherwise = pure (VarMap.singleton (toVar a) (ty, varInfo a))
       checkPattern (RowsTy _ _) (PatLit RecNil) = pure mempty
       checkPattern (ExactRowsTy _) (PatLit RecNil) = pure mempty
       checkPattern ty' (PatLit l) = do
@@ -163,16 +225,26 @@ checkTerm s t@(Match e bs) = flip withContext t $ do
       checkPattern ty' (Constr a) =
         case VarMap.lookup (toVar a) (vars s) of
           Nothing -> throwError (NoSuchVar a)
-          Just ty | inst ty `uniOpen` ty' -> pure mempty
-                  | otherwise -> throwError (TypeMismatch ty' (inst ty))
+          Just (ty, inf)
+            -- Ensure types line up
+            | inst ty `apartOpen` ty' -> throwError (TypeMismatch ty' (inst ty))
+            -- Ensure we're matching on a constructor
+            | inf /= varInfo a -> throwError (InfoMismatch a inf (varInfo a))
+            | inf /= DataConVar  -> throwError (InfoMismatch a DataConVar (varInfo a))
+            | otherwise -> pure mempty
       checkPattern ty' (Destr a p) =
         case VarMap.lookup (toVar a) (vars s) of
           Nothing -> throwError (NoSuchVar a)
-          Just ty | ForallTy Irrelevant x r <- inst ty
-                  , Just s <- r `unify` ty'
-                  -- TODO: Do we need Relevant as well?
-                  -> checkPattern (substituteInType s x) p
-                  | otherwise -> throwError (TypeMismatch (ForallTy Irrelevant unknownTyvar ty') (inst ty))
+          Just (ty, inf)
+            -- Ensure we're matching on a constructor
+            | inf /= varInfo a -> throwError (InfoMismatch a inf (varInfo a))
+            | inf /= DataConVar  -> throwError (InfoMismatch a DataConVar (varInfo a))
+            -- Ensure types line up
+            | ForallTy Irrelevant x r <- inst ty
+            , Just s <- r `unify` ty'
+            -- TODO: Do we need Relevant as well?
+            -> checkPattern (substituteInType s x) p
+            | otherwise -> throwError (TypeMismatch (ForallTy Irrelevant unknownTyvar ty') (inst ty))
       checkPattern ty@(RowsTy ext ts) (PatExtend f fs) = do
         v <- checkPattern ext f
         vs <- for fs $ \(t, p) ->
@@ -281,14 +353,20 @@ checkType :: (IsVar a, MonadError (CoreError a) m)
          => Scope a
          -> Type a
          -> m ()
-checkType s (ConTy v) = if toVar v `VarSet.member` types s
-                       then pure ()
-                       else throwError (NoSuchVar v)
-checkType _ (VarTy _) = pure ()
+checkType s (ConTy v) =
+  case VarMap.lookup (toVar v) (types s) of
+    Nothing -> throwError (NoSuchVar v)
+    Just inf | inf /= varInfo v -> throwError (InfoMismatch v inf (varInfo v))
+             | not (isTypeInfo inf) -> throwError (InfoIllegal v TypeConVar inf)
+             | otherwise -> pure ()
+checkType _ (VarTy v)
+  | varInfo v /= TypeVar = throwError (InfoIllegal v TypeVar (varInfo v))
+  | otherwise = pure ()
 checkType s (ForallTy Irrelevant a r) = checkType s a >> checkType s r
-checkType s (ForallTy (Relevant vs) c v) =
+checkType s (ForallTy (Relevant vs) c v) = do
+  unless (varInfo vs == TypeVar) (throwError (InfoIllegal vs TypeVar (varInfo vs)))
   let s' = s { tyVars = VarSet.insert (toVar vs) (tyVars s) }
-  in checkType s' c >> checkType s' v
+  checkType s' c >> checkType s' v
 checkType s (AppTy f x) = checkType s f >> checkType s x
 checkType s (RowsTy f fs) = checkType s f >> traverse_ (checkType s . snd) fs
 checkType s (ExactRowsTy fs) = traverse_ (checkType s . snd) fs
@@ -321,10 +399,11 @@ litTy LitFalse = fromVar <$> tyBool
 litTy Unit = fromVar <$> tyUnit
 litTy RecNil = ExactRowsTy []
 
-uni, apart, uniOpen :: IsVar a => Type a -> Type a -> Bool
+uni, apart, uniOpen, apartOpen :: IsVar a => Type a -> Type a -> Bool
 uni = unifyClosed
 apart a b = not (uni a b)
 uniOpen a b = isJust (unify a b)
+apartOpen a b = not (uniOpen a b)
 
 patternVars :: Pattern a -> [(a, Type a)]
 patternVars (Capture v ty) = [(v, ty)]

--- a/src/Core/Lint.hs
+++ b/src/Core/Lint.hs
@@ -10,7 +10,6 @@ import Control.Monad.Except
 
 import qualified Data.VarMap as VarMap
 import qualified Data.VarSet as VarSet
-import Data.VarSet (IsVar(..))
 import Data.Traversable
 import Data.Foldable
 import Data.Function

--- a/src/Core/Occurrence.hs
+++ b/src/Core/Occurrence.hs
@@ -12,9 +12,9 @@ module Core.Occurrence
 import Control.Lens hiding ((#))
 
 import Core.Core as C
+import Core.Var
 
 import qualified Data.VarMap as VarMap
-import Data.VarSet (IsVar(..))
 import Data.Triple
 import Data.Maybe
 import Data.Data

--- a/src/Core/Optimise.hs
+++ b/src/Core/Optimise.hs
@@ -15,7 +15,6 @@ import Control.Lens
 
 import qualified Data.VarMap as VarMap
 import qualified Data.Text as T
-import Data.VarSet (IsVar(..))
 import Data.Foldable
 import Data.Triple
 import Data.Maybe

--- a/src/Core/Optimise/DeadCode.hs
+++ b/src/Core/Optimise/DeadCode.hs
@@ -2,7 +2,6 @@
 module Core.Optimise.DeadCode ( deadCodePass ) where
 
 import qualified Data.VarSet as VarSet
-import Data.VarSet (IsVar(..))
 import Data.Triple
 import Data.List
 

--- a/src/Core/Optimise/DeadCode.hs
+++ b/src/Core/Optimise/DeadCode.hs
@@ -25,7 +25,7 @@ deadCodePass = snd . freeS emptyScope Nothing where
            else (fxs, xs')
   freeS s m (StmtLet vs:xs) =
     let m' = find (\x -> case toVar x of
-                           TgName "main" _ -> True
+                           CoVar _ "main" _ -> True
                            _ -> False) (map fst3 vs)
         s' = extendPureFuns s vs
     in case uncurry (buildLet s' vs) (freeS s' (m <|> m') xs) of

--- a/src/Core/Optimise/Inline.hs
+++ b/src/Core/Optimise/Inline.hs
@@ -8,7 +8,6 @@ import Control.Monad.Gen
 
 import qualified Data.VarMap as VarMap
 import qualified Data.VarSet as VarSet
-import qualified Data.Map.Strict as Map
 import Data.VarSet (IsVar(..))
 import Data.Triple
 
@@ -53,8 +52,8 @@ inlineVariablePass = transS (InlineScope mempty mempty) where
     case f' of
       Ref r _
         | Just (Lam (TypeArgument v _) b, score) <- VarMap.lookup (toVar r) (scores s)
-        , score <= limit -> refresh $ substituteInTys (Map.singleton v t) b
-      Lam (TypeArgument v _) b -> pure $ substituteInTys (Map.singleton v t) b
+        , score <= limit -> refresh $ substituteInTys (VarMap.singleton (toVar v) t) b
+      Lam (TypeArgument v _) b -> pure $ substituteInTys (VarMap.singleton (toVar v) t) b
       f' -> pure $ TyApp f' t
   transT s (Extend t rs) = Extend <$> transA s t
                                   <*> traverse (third3A (transA s)) rs

--- a/src/Core/Optimise/Inline.hs
+++ b/src/Core/Optimise/Inline.hs
@@ -8,7 +8,6 @@ import Control.Monad.Gen
 
 import qualified Data.VarMap as VarMap
 import qualified Data.VarSet as VarSet
-import Data.VarSet (IsVar(..))
 import Data.Triple
 
 import Core.Optimise

--- a/src/Core/Optimise/Joinify.hs
+++ b/src/Core/Optimise/Joinify.hs
@@ -4,7 +4,6 @@ module Core.Optimise.Joinify where
 import Control.Monad.Gen
 import Control.Lens
 
-import Data.VarSet (IsVar(..))
 import Data.Triple
 
 import Core.Optimise

--- a/src/Core/Optimise/Newtype.hs
+++ b/src/Core/Optimise/Newtype.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Core.Optimise.Newtype (killNewtypePass) where
 
-import Control.Monad.Infer (Gen, fresh)
+import Control.Monad.Gen
 import Control.Monad
 import Control.Lens
 
@@ -51,7 +51,7 @@ newtypeMatch _ [] = Nothing
 
 newtypeCo :: IsVar a => (a, Type a) -> (Type a, Type a) -> Gen Int (Stmt a, Coercion a)
 newtypeCo (cn, tp) (dom, cod) = do
-  var <- fresh
+  var <- fresh ValueVar
   let con = [(cn, tp, Atom (wrap tp (work phi)))]
       wrap (ForallTy (Relevant v) c t) e = Lam (TypeArgument v c) (Atom (wrap t e))
       wrap _ e = e
@@ -77,7 +77,7 @@ goBinding m = traverse (third3A goTerm) where
   goTerm (Cast f t) = Cast <$> goAtom f <*> pure t
   goTerm (Match a x) = case newtypeMatch m x of
     Just (phi, Arm { _armPtrn = Destr _ p, _armBody = bd, _armVars = vs, _armTyvars = tvs }) -> do
-      var <- fresh
+      var <- fresh ValueVar
       let Just (_, castCodomain) = relates phi
       bd' <- goTerm (Match (Ref (fromVar var) castCodomain) [Arm { _armPtrn = p, _armTy = castCodomain
                                                                  , _armBody = bd, _armVars = vs, _armTyvars = tvs }])

--- a/src/Core/Optimise/Newtype.hs
+++ b/src/Core/Optimise/Newtype.hs
@@ -6,7 +6,6 @@ import Control.Monad
 import Control.Lens
 
 import qualified Data.VarMap as V
-import Data.VarSet (IsVar(..))
 import Data.Triple
 
 import Core.Optimise

--- a/src/Core/Optimise/Reduce.hs
+++ b/src/Core/Optimise/Reduce.hs
@@ -10,7 +10,6 @@ module Core.Optimise.Reduce
 import qualified Data.Map.Strict as Map
 import qualified Data.VarMap as VarMap
 import qualified Data.Text as T
-import Data.VarSet (IsVar(..))
 import Data.Triple
 import Data.List
 

--- a/src/Core/Optimise/Sinking.hs
+++ b/src/Core/Optimise/Sinking.hs
@@ -4,7 +4,6 @@ module Core.Optimise.Sinking (sinkingPass) where
 import Control.Lens
 
 import qualified Data.VarSet as VarSet
-import Data.VarSet (IsVar(..))
 import Data.Triple
 
 import Core.Optimise

--- a/src/Core/Simplify.hs
+++ b/src/Core/Simplify.hs
@@ -17,12 +17,10 @@ import Core.Lint
 import Control.Monad.Gen
 import Control.Monad
 
-import Syntax (Var(..), Resolved)
-
 lintPasses :: Bool
 lintPasses = True
 
-optmOnce :: [Stmt (Var Resolved)] -> Gen Int [Stmt (Var Resolved)]
+optmOnce :: [Stmt CoVar] -> Gen Int [Stmt CoVar]
 optmOnce = passes where
   passes = foldr1 (>=>) $ linted
            [ pure
@@ -44,9 +42,9 @@ optmOnce = passes where
     = intersperse (pure . (runLint =<< checkStmt emptyScope))
     | otherwise = id
 
-optimise :: [Stmt (Var Resolved)] -> Gen Int [Stmt (Var Resolved)]
+optimise :: [Stmt CoVar] -> Gen Int [Stmt CoVar]
 optimise = go 25 where
-  go :: Integer -> [Stmt (Var Resolved)] -> Gen Int [Stmt (Var Resolved)]
+  go :: Integer -> [Stmt CoVar] -> Gen Int [Stmt CoVar]
   go k sts
     | k > 0 = go (k - 1) . (runLint =<< checkStmt emptyScope) =<< optmOnce sts
     | otherwise = pure sts

--- a/src/Core/Types.hs
+++ b/src/Core/Types.hs
@@ -9,6 +9,7 @@ module Core.Types
 import qualified Data.VarMap as VarMap
 import Core.Builtin
 import Core.Core
+import Core.Var
 
 import Control.Lens
 
@@ -17,7 +18,6 @@ import Control.Applicative
 
 import Data.Traversable
 import Data.Foldable
-import Data.VarSet(IsVar(..))
 import Data.Maybe
 import Data.List
 

--- a/src/Core/Types.hs
+++ b/src/Core/Types.hs
@@ -6,7 +6,7 @@ module Core.Types
   , replaceTy
   ) where
 
-import qualified Data.Map.Strict as Map
+import qualified Data.VarMap as VarMap
 import Core.Builtin
 import Core.Core
 
@@ -58,20 +58,20 @@ approximateType (TyApp f at) = do
       go x = x
   pure (replace t)
 
-unify :: IsVar a => Type a -> Type a -> Maybe (Map.Map a (Type a))
+unify :: IsVar a => Type a -> Type a -> Maybe (VarMap.Map (Type a))
 unify = unifyWith mempty
 
-unifyWith :: IsVar a => Map.Map a (Type a) -> Type a -> Type a -> Maybe (Map.Map a (Type a))
+unifyWith :: IsVar a => VarMap.Map (Type a) -> Type a -> Type a -> Maybe (VarMap.Map (Type a))
 unifyWith m a b = execStateT (unify' a b) m
 
-unify' :: IsVar a => Type a -> Type a -> StateT (Map.Map a (Type a)) Maybe ()
+unify' :: IsVar a => Type a -> Type a -> StateT (VarMap.Map (Type a)) Maybe ()
 unify' t'@(VarTy v) t
   | t' == t = pure ()
   | otherwise = do
-      x <- gets (Map.lookup v)
+      x <- gets (VarMap.lookup (toVar v))
       case x of
         Just t' -> unify' t t'
-        Nothing -> modify (Map.insert v t)
+        Nothing -> modify (VarMap.insert (toVar v) t)
 unify' t (VarTy v) = unify' (VarTy v) t
 unify' (ConTy v) (ConTy v') = mempty <$ guard (v == v')
 unify' (ForallTy Irrelevant a b) (ForallTy Irrelevant a' b') = liftA2 (<>) (unify' a a') (unify' b b')
@@ -93,10 +93,10 @@ replaceTy var at = transform (go var) where
 unifyClosed :: IsVar a => Type a -> Type a -> Bool
 unifyClosed = go mempty where
   go _ (ConTy a) (ConTy b) = a == b
-  go s (VarTy a) (VarTy b) = fromMaybe a (Map.lookup a s) == b
+  go s (VarTy a) (VarTy b) = fromMaybe a (VarMap.lookup (toVar a) s) == b
   go s (ForallTy (Relevant v) c ty) (ForallTy (Relevant v') c' ty')
     | v == v' = go s c c' && go s ty ty'
-    | otherwise = go (Map.insert v v' s) ty ty' && go s c c'
+    | otherwise = go (VarMap.insert (toVar v) v' s) ty ty' && go s c c'
   go s (ForallTy Irrelevant a r) (ForallTy Irrelevant a' r') = go s a a' && go s r r'
   go s (AppTy f x) (AppTy f' x') = go s f f' && go s x x'
   go s (RowsTy f ts) (RowsTy f' ts') = go s f f' && and (zipWith (\(l, t) (l', t') -> l == l' && go s t t') (sortOn fst ts) (sortOn fst ts'))

--- a/src/Core/Var.hs
+++ b/src/Core/Var.hs
@@ -23,9 +23,10 @@ instance Ord CoVar where
 
 data VarInfo
   = ValueVar
+  | DataConVar
+  | TypeConVar
   | TypeVar
-  | TyvarVar
-  | CoeVar
+  | CastVar
   deriving (Eq, Show, Ord, Generic, Data)
 
 makeLenses ''CoVar
@@ -34,3 +35,11 @@ makePrisms ''VarInfo
 
 instance Pretty CoVar where
   pretty (CoVar i v _) = text v <> scomment (string "#" <> string (show i))
+
+class (Eq a, Ord a, Pretty a, Show a) => IsVar a where
+  toVar :: a -> CoVar
+  fromVar :: CoVar -> a
+
+instance IsVar CoVar where
+  toVar = id
+  fromVar = id

--- a/src/Core/Var.hs
+++ b/src/Core/Var.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE DeriveGeneric, DeriveDataTypeable, TemplateHaskell #-}
+
+module Core.Var where
+
+import qualified Data.Text as T
+import Control.Lens
+import GHC.Generics
+import Pretty
+import Data.Data
+
+data CoVar =
+  CoVar { _covarId :: {-# UNPACK #-} !Int
+        , _covarName :: T.Text
+        , _covarInfo :: VarInfo
+        }
+  deriving (Show, Generic, Data)
+
+instance Eq CoVar where
+  (CoVar a _ _) == (CoVar b _ _) = a == b
+
+instance Ord CoVar where
+  (CoVar a _ _) `compare` (CoVar b _ _) = a `compare` b
+
+data VarInfo
+  = ValueVar
+  | TypeVar
+  | TyvarVar
+  | CoeVar
+  deriving (Eq, Show, Ord, Generic, Data)
+
+makeLenses ''CoVar
+makePrisms ''VarInfo
+
+
+instance Pretty CoVar where
+  pretty (CoVar i v _) = text v <> scomment (string "#" <> string (show i))

--- a/src/Core/Var.hs
+++ b/src/Core/Var.hs
@@ -40,6 +40,19 @@ class (Eq a, Ord a, Pretty a, Show a) => IsVar a where
   toVar :: a -> CoVar
   fromVar :: CoVar -> a
 
+  varInfo :: a -> VarInfo
+  varInfo = view covarInfo . toVar
+
 instance IsVar CoVar where
   toVar = id
   fromVar = id
+
+isValueInfo, isTypeInfo :: VarInfo -> Bool
+
+isValueInfo ValueVar = True
+isValueInfo DataConVar = True
+isValueInfo _ = False
+
+isTypeInfo TypeConVar = True
+isTypeInfo DataConVar = True
+isTypeInfo _ = False

--- a/src/Data/VarMap.hs
+++ b/src/Data/VarMap.hs
@@ -1,44 +1,50 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving, DerivingStrategies, FlexibleInstances #-}
 module Data.VarMap
   ( Map
-  , fromList
-  , lookup, member
+  , fromList, toList
+  , lookup, member, findWithDefault
   , insert, delete
   , map, singleton, union, unionSemigroup
+  , foldrWithKey
   , (<>), mempty
   ) where
 
 import qualified Data.IntMap.Strict as Map
 import qualified Data.IntMap.Merge.Strict as Map
+import qualified Data.Text as T
+import qualified Data.List as L
+import Data.Coerce
 import Prelude hiding (lookup, map)
 
-import Syntax.Pretty (Var(..), Resolved)
+import Control.Arrow
 
-import Data.Coerce
+import Core.Var
 
 newtype Map a
   = Map (Map.IntMap a)
   deriving (Eq, Show, Ord)
-  deriving newtype (Semigroup, Monoid)
+  deriving newtype (Semigroup, Monoid, Functor, Foldable)
 
-insert :: Var Resolved -> a -> Map a -> Map a
-insert (TgName _ x) v (Map k) = Map (Map.insert x v k)
-insert _ _ x = x
+insert :: CoVar -> a -> Map a -> Map a
+insert (CoVar x _ _) v (Map k) = Map (Map.insert x v k)
 
-delete :: Var Resolved -> Map a -> Map a
-delete (TgName _ x) (Map k) = Map (Map.delete x k)
-delete _ x = x
+delete :: CoVar -> Map a -> Map a
+delete (CoVar x _ _) (Map k) = Map (Map.delete x k)
 
-fromList :: [(Var Resolved, a)] -> Map a
+fromList :: [(CoVar, a)] -> Map a
 fromList = foldr (uncurry insert) mempty
 
-member :: Var Resolved -> Map a -> Bool
-member (TgName _ x) (Map m) = Map.member x m
-member _ _ = False
+toList :: Map a -> [(CoVar, a)]
+toList (Map m) = L.map (first create) (Map.toList m)
 
-lookup :: Var Resolved -> Map a -> Maybe a
-lookup (TgName _ x) (Map m) = Map.lookup x m
-lookup _ _ = Nothing
+member :: CoVar -> Map a -> Bool
+member (CoVar x _ _) (Map m) = Map.member x m
+
+findWithDefault :: a -> CoVar -> Map a -> a
+findWithDefault d (CoVar x _ _) (Map m) = Map.findWithDefault d x m
+
+lookup :: CoVar -> Map a -> Maybe a
+lookup (CoVar x _ _) (Map m) = Map.lookup x m
 
 union :: Map a -> Map a -> Map a
 union (Map a) (Map b) = Map (Map.union a b)
@@ -46,9 +52,14 @@ union (Map a) (Map b) = Map (Map.union a b)
 map :: (a -> b) -> Map a -> Map b
 map f (Map a) = Map (Map.map f a)
 
-singleton :: Var Resolved -> a ->  Map a
-singleton (TgName _ x) v = coerce (Map.singleton x v)
-singleton _ _ = Map Map.empty
+singleton :: CoVar -> a ->  Map a
+singleton (CoVar x _ _) v = coerce (Map.singleton x v)
 
 unionSemigroup :: Semigroup a => Map a -> Map a -> Map a
 unionSemigroup (Map l) (Map r) = Map (Map.merge Map.preserveMissing Map.preserveMissing (Map.zipWithMatched (const (<>))) l r)
+
+foldrWithKey :: (CoVar -> a -> b -> b) -> b -> Map a -> b
+foldrWithKey f b (Map m) = Map.foldrWithKey (f . create) b m
+
+create :: Map.Key -> CoVar
+create i = CoVar i (T.singleton '?') ValueVar

--- a/src/Data/VarSet.hs
+++ b/src/Data/VarSet.hs
@@ -5,7 +5,6 @@ module Data.VarSet
   , member, notMember, insert
   , difference, union, intersection, singleton, delete
   , (<>), mempty, isEmpty
-  , IsVar(..)
   ) where
 
 import qualified Data.IntSet as Set
@@ -14,9 +13,6 @@ import qualified Data.Text as T
 import Core.Var
 
 import Data.Coerce
-import Data.Data
-
-import Pretty(Pretty)
 
 newtype Set
   = Set Set.IntSet
@@ -55,11 +51,3 @@ delete (CoVar x _ _) set = coerce (Set.delete x (coerce set))
 
 isEmpty :: Set -> Bool
 isEmpty = coerce Set.null
-
-class (Data a, Eq a, Ord a, Pretty a, Show a) => IsVar a where
-  toVar :: a -> CoVar
-  fromVar :: CoVar -> a
-
-instance IsVar CoVar where
-  toVar = id
-  fromVar = id

--- a/src/Data/VarSet.hs
+++ b/src/Data/VarSet.hs
@@ -11,7 +11,7 @@ module Data.VarSet
 import qualified Data.IntSet as Set
 import qualified Data.Text as T
 
-import Syntax.Pretty (Var(..), Resolved)
+import Core.Var
 
 import Data.Coerce
 import Data.Data
@@ -23,23 +23,20 @@ newtype Set
   deriving (Eq, Show, Ord)
   deriving newtype (Semigroup, Monoid)
 
-insert :: Var Resolved -> Set -> Set
-insert (TgName _ x) (Set k) = Set (Set.insert x k)
-insert _ x = x
+insert :: CoVar -> Set -> Set
+insert (CoVar x _ _) (Set k) = Set (Set.insert x k)
 
-fromList :: [Var Resolved] -> Set
+fromList :: [CoVar] -> Set
 fromList = foldr insert mempty
 
-toList :: Set -> [Var Resolved]
-toList (Set s) = map (TgName (T.singleton '?')) (Set.toList s)
+toList :: Set -> [CoVar]
+toList (Set s) = map (\x -> CoVar x (T.singleton '?') ValueVar) (Set.toList s)
 
-member :: Var Resolved -> Set -> Bool
-member (TgName _ x) set = Set.member x (coerce set)
-member _ _ = False
+member :: CoVar -> Set -> Bool
+member (CoVar x _ _) set = Set.member x (coerce set)
 
-notMember :: Var Resolved -> Set -> Bool
-notMember (TgName _ x) set = Set.notMember x (coerce set)
-notMember _ _ = True
+notMember :: CoVar -> Set -> Bool
+notMember (CoVar x _ _) set = Set.notMember x (coerce set)
 
 difference :: Set -> Set -> Set
 difference = coerce Set.difference
@@ -50,21 +47,19 @@ union = coerce Set.union
 intersection :: Set -> Set -> Set
 intersection = coerce Set.intersection
 
-singleton :: Var Resolved -> Set
-singleton (TgName _ x) = coerce (Set.singleton x)
-singleton _ = coerce Set.empty
+singleton :: CoVar -> Set
+singleton (CoVar x _ _) = coerce (Set.singleton x)
 
-delete :: Var Resolved -> Set -> Set
-delete (TgName _ x) set = coerce (Set.delete x (coerce set))
-delete _ set = set
+delete :: CoVar -> Set -> Set
+delete (CoVar x _ _) set = coerce (Set.delete x (coerce set))
 
 isEmpty :: Set -> Bool
 isEmpty = coerce Set.null
 
 class (Data a, Eq a, Ord a, Pretty a, Show a) => IsVar a where
-  toVar :: a -> Var Resolved
-  fromVar :: Var Resolved -> a
+  toVar :: a -> CoVar
+  fromVar :: CoVar -> a
 
-instance IsVar (Var Resolved) where
+instance IsVar CoVar where
   toVar = id
   fromVar = id


### PR DESCRIPTION
This allows us to attach additional annotations to variables in the future. Namely the arity of join points.

Variables are also tagged with their type (type, tyvar, value, coercion), which we might want to verify in core at a later date - not currently a priority however.