### PR TITLE
Semantic pretty printing

### DIFF
--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -87,10 +87,12 @@ executable lexer
                      , Parser.Wrapper
                      , Parser.Unicode
 
+                     , Text.Pretty
+                     , Text.Pretty.Semantic
+
                      , Data.Position
                      , Data.Span
                      , Data.Spanned
-                     , Pretty
 
 library amulet
   build-depends:       mtl >= 2.2 && < 2.3
@@ -139,13 +141,17 @@ library amulet
                      , Types.Infer.Builtin
                      , Types.Infer.Pattern
                      , Types.Infer.Constructor
+                     -- Pretty
+                     , Text.Pretty
+                     , Text.Pretty.Semantic
                      -- Data
                      , Data.Span
                      , Data.VarMap
                      , Data.VarSet
                      , Data.Triple
-                     , Data.Position
                      , Data.Spanned
+                     , Data.Position
+                     , Data.Diagnostic
                      -- Core
                      , Core.Var
                      , Core.Core
@@ -171,6 +177,5 @@ library amulet
 
                      , Backend.Escape
                      -- Infra
-                     , Pretty
                      , Control.Monad.Infer
                      , Control.Monad.Infer.Error

--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -153,7 +153,6 @@ library amulet
                      , Data.Triple
                      , Data.Spanned
                      , Data.Position
-                     , Data.Diagnostic
                      -- Core
                      , Core.Var
                      , Core.Core

--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -88,6 +88,7 @@ executable lexer
                      , Parser.Unicode
 
                      , Text.Pretty
+                     , Text.Pretty.Ansi
                      , Text.Pretty.Semantic
 
                      , Data.Position
@@ -143,6 +144,7 @@ library amulet
                      , Types.Infer.Constructor
                      -- Pretty
                      , Text.Pretty
+                     , Text.Pretty.Ansi
                      , Text.Pretty.Semantic
                      -- Data
                      , Data.Span

--- a/compiler/Errors.hs
+++ b/compiler/Errors.hs
@@ -16,7 +16,7 @@ import qualified "amuletml" Control.Monad.Infer as I
 
 import qualified "amuletml" Syntax.Resolve as R
 
-import "amuletml" Pretty
+import "amuletml" Text.Pretty.Semantic
 
 type FileMap = [(SourceName, T.Text)]
 

--- a/compiler/Main.hs
+++ b/compiler/Main.hs
@@ -34,7 +34,7 @@ import Core.Lower (runLowerT, lowerProg)
 import Core.Core (Stmt)
 import Core.Var (CoVar)
 
-import Pretty (Pretty(pretty), putDoc, (<+>), colon)
+import Text.Pretty.Semantic (Pretty(pretty), putDoc, (<+>), colon)
 
 import Parser.Wrapper (runParser)
 import Parser.Error (ParseError)

--- a/compiler/Test/Core/Backend.hs
+++ b/compiler/Test/Core/Backend.hs
@@ -21,7 +21,7 @@ import Core.Lower
 import Backend.Lua
 
 import Syntax.Pretty()
-import Pretty
+import Text.Pretty.Semantic
 
 result :: String -> T.Text -> String
 result file contents = runGen $ do

--- a/compiler/Test/Core/Backend.hs
+++ b/compiler/Test/Core/Backend.hs
@@ -23,7 +23,7 @@ import Backend.Lua
 import Syntax.Pretty()
 import Text.Pretty.Semantic
 
-result :: String -> T.Text -> String
+result :: String -> T.Text -> T.Text
 result file contents = runGen $ do
   let (Just parsed, _) = runParser file (L.fromStrict contents) parseInput
   Right (resolved, _) <- resolveProgram RS.builtinScope RS.emptyModules parsed
@@ -31,7 +31,7 @@ result file contents = runGen $ do
   Right (inferred, env) <- inferProgram builtinsEnv desugared
   lower <- runLowerT (lowerProg inferred)
   optm <- optimise lower
-  pure . display . renderPretty 0.8 120 . (<##>empty)
+  pure . display . simplifyDoc . renderPretty 0.8 120 . (<##>empty)
        . pretty . compileProgram env $ optm
 
 tests :: IO TestTree

--- a/compiler/Test/Core/Lint.hs
+++ b/compiler/Test/Core/Lint.hs
@@ -24,7 +24,7 @@ import Core.Simplify
 import Core.Lint
 import Core.Var
 
-import Pretty
+import Text.Pretty.Semantic
 
 import Parser.Wrapper (runParser)
 import Parser (parseInput)

--- a/compiler/Test/Core/Lint.hs
+++ b/compiler/Test/Core/Lint.hs
@@ -85,10 +85,10 @@ testLint f file = do
         c' <- f c
         case runLintOK (checkStmt emptyScope c') of
           Right _ -> pure $ pure ()
-          Left es -> pure $ assertFailure $ "Core lint failed: " ++ render (pretty es)
-      CParse es -> pure $ assertFailure $ render $ vsep $ map (\e -> string "Parse error: " <+> pretty e <+> " at " <+> pretty (annotation e)) es
-      CResolve e -> pure $ assertFailure $ "Resolution error: " ++ render (pretty e)
-      CInfer e -> pure $ assertFailure $ "Type error: " ++ render (pretty e)
+          Left es -> pure $ assertFailure $ "Core lint failed: " ++ displayS (pretty es)
+      CParse es -> pure $ assertFailure $ displayS $ vsep $ map (\e -> string "Parse error: " <+> pretty e <+> " at " <+> pretty (annotation e)) es
+      CResolve e -> pure $ assertFailure $ "Resolution error: " ++ displayS (pretty e)
+      CInfer e -> pure $ assertFailure $ "Type error: " ++ displayS (pretty e)
 
 testLintLower, testLintSimplify :: String -> Assertion
 testLintLower = testLint pure

--- a/compiler/Test/Parser/Lexer.hs
+++ b/compiler/Test/Parser/Lexer.hs
@@ -11,7 +11,7 @@ import Data.Spanned
 import Parser.Wrapper (Token(..), runLexer)
 import Parser.Lexer
 
-import Pretty
+import Text.Pretty.Semantic
 
 result :: String -> T.Text -> String
 result file contents =

--- a/compiler/Test/Parser/Lexer.hs
+++ b/compiler/Test/Parser/Lexer.hs
@@ -13,7 +13,7 @@ import Parser.Lexer
 
 import Text.Pretty.Semantic
 
-result :: String -> T.Text -> String
+result :: String -> T.Text -> T.Text
 result file contents =
   case runLexer file (L.fromStrict contents) lexerContextScan of
     (Just toks, []) -> disp $ writeToks 1 True toks
@@ -30,7 +30,7 @@ result file contents =
           = space <> string (show tc) <> writeToks l False ts
 
         prettyErrs = vsep . map (\e -> pretty (annotation e) <> colon <+> pretty e)
-        disp = display . renderPretty 0.8 120
+        disp = display . simplifyDoc . renderPretty 0.8 120
 
 tests :: IO TestTree
 tests = testGroup "Test.Parser.Lexer" <$> goldenDir result "tests/lexer/" ".ml"

--- a/compiler/Test/Parser/Parser.hs
+++ b/compiler/Test/Parser/Parser.hs
@@ -13,7 +13,7 @@ import Parser
 import Syntax.Pretty()
 import Text.Pretty.Semantic
 
-result :: String -> T.Text -> String
+result :: String -> T.Text -> T.Text
 result file contents =
   case runParser file (L.fromStrict contents) parseInput of
     (Just res, []) -> disp $ pretty res <##> empty
@@ -22,8 +22,7 @@ result file contents =
     (Nothing, es) -> disp $ prettyErrs es <##> empty
 
   where prettyErrs = vsep . map (\e -> pretty (annotation e) <> colon <+> pretty e)
-        disp = display . renderPretty 0.8 120
-
+        disp = display . simplifyDoc . renderPretty 0.8 120
 
 tests :: IO TestTree
 tests = testGroup "Test.Parser.Parser" <$> goldenDir result "tests/parser/" ".ml"

--- a/compiler/Test/Parser/Parser.hs
+++ b/compiler/Test/Parser/Parser.hs
@@ -11,7 +11,7 @@ import Parser.Wrapper (runParser)
 import Parser
 
 import Syntax.Pretty()
-import Pretty
+import Text.Pretty.Semantic
 
 result :: String -> T.Text -> String
 result file contents =

--- a/compiler/Test/Syntax/Gen.hs
+++ b/compiler/Test/Syntax/Gen.hs
@@ -21,7 +21,7 @@ import Hedgehog hiding (Var) -- fuck you
 
 import Test.Types.Util
 
-import Pretty (pretty)
+import Text.Pretty.Semantic (pretty)
 
 genVar :: MonadGen m => m (Var Resolved)
 genVar = do

--- a/compiler/Test/Syntax/Resolve.hs
+++ b/compiler/Test/Syntax/Resolve.hs
@@ -17,7 +17,7 @@ import Syntax.Resolve (resolveProgram)
 import Syntax.Pretty()
 import Text.Pretty.Semantic
 
-result :: String -> T.Text -> String
+result :: String -> T.Text -> T.Text
 result file contents = runGen $ do
   let (Just parsed, _) = runParser file (L.fromStrict contents) parseInput
   resolved <- resolveProgram RS.builtinScope RS.emptyModules parsed

--- a/compiler/Test/Syntax/Resolve.hs
+++ b/compiler/Test/Syntax/Resolve.hs
@@ -15,7 +15,7 @@ import qualified Syntax.Resolve.Scope as RS
 import Syntax.Resolve (resolveProgram)
 
 import Syntax.Pretty()
-import Pretty
+import Text.Pretty.Semantic
 
 result :: String -> T.Text -> String
 result file contents = runGen $ do

--- a/compiler/Test/Types/Check.hs
+++ b/compiler/Test/Types/Check.hs
@@ -23,16 +23,17 @@ import Syntax.Desugar (desugarProgram)
 import Syntax.Types (difference, toMap)
 
 import Syntax.Pretty()
+
 import Text.Pretty.Semantic
 
-result :: String -> T.Text -> String
+result :: String -> T.Text -> T.Text
 result file contents = runGen $ do
   let (Just parsed, _) = runParser file (L.fromStrict contents) parseInput
   Right (resolved, _) <- resolveProgram RS.builtinScope RS.emptyModules parsed
   desugared <- desugarProgram resolved
   inferred <- inferProgram builtinsEnv desugared
 
-  pure . displayDecorated decoratePlain . renderPretty 0.8 120 . (<##>empty)
+  pure . display . simplifyDoc . renderPretty 0.8 120 . (<##>empty)
        . either (pretty . reportT) (reportEnv . snd) $ inferred
 
   where

--- a/compiler/Test/Types/Check.hs
+++ b/compiler/Test/Types/Check.hs
@@ -23,7 +23,7 @@ import Syntax.Desugar (desugarProgram)
 import Syntax.Types (difference, toMap)
 
 import Syntax.Pretty()
-import Pretty
+import Text.Pretty.Semantic
 
 result :: String -> T.Text -> String
 result file contents = runGen $ do

--- a/compiler/Test/Types/Infer.hs
+++ b/compiler/Test/Types/Infer.hs
@@ -8,7 +8,7 @@ import Hedgehog
 import Test.Types.Util
 import Test.Syntax.Gen
 
-import Pretty (pretty)
+import Text.Pretty.Semantic (pretty)
 
 prop_wellTyped :: Property
 prop_wellTyped = property $ do

--- a/compiler/Test/Types/Util.hs
+++ b/compiler/Test/Types/Util.hs
@@ -11,9 +11,9 @@ import qualified "amuletml" Control.Monad.Infer as MonadInfer
 import "amuletml" Control.Monad.Infer.Error
 import "amuletml" Control.Monad.Infer (Constraint(..), SomeReason(..), TypeError)
 
+import "amuletml" Text.Pretty.Semantic
 import "amuletml" Data.Spanned
 import "amuletml" Data.Span
-import "amuletml" Pretty
 
 import qualified Data.Sequence as Seq
 
@@ -52,7 +52,7 @@ instance Reasonable Blame p where
   blame _ = string "a test"
 
 instance Spanned (Blame p) where
-  annotation (Blame x) =x 
+  annotation (Blame x) =x
 
 instance Pretty (Blame p) where
   pretty _ = empty

--- a/compiler/Test/Util.hs
+++ b/compiler/Test/Util.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Test.Util where
 
 import Hedgehog
@@ -21,45 +22,42 @@ hedgehog :: Group -> TestTree
 hedgehog Group { groupName = n, groupProperties = ps }
   = testGroup (unGroupName n) (map (\(n, p) -> testProperty (unPropertyName n) p) ps)
 
-golden :: FilePath -> String -> Assertion
+golden :: FilePath -> T.Text -> Assertion
 golden expFile result = do
-  expected <- (Just <$> readFile expFile) `catch` catchIO
+  expected <- (Just <$> T.readFile expFile) `catch` catchIO
   case expected of
     Nothing -> do
-      writeFile expFile result
+      T.writeFile expFile result
       assertFailure "File does not exist, generated"
     Just expected -> do
       let expected' = process expected
       let result' = process result
       if expected' /= result' then
         let contextDiff = getDiff expected' result'
-        in assertFailure (formatDoc contextDiff)
+        in assertFailure (T.unpack (formatDoc contextDiff))
       else pure ()
 
   where
     catchIO :: IOException -> IO (Maybe a)
     catchIO _ = pure Nothing
 
-    process' [] = ([], [])
-    process' ('\n':xs) = (process xs, [])
-    process' (x:xs) = (x:) <$> process' xs
-    process xs = let (ls, l) = process' xs in l:ls
+    process = T.split (=='\n') . T.dropAround (=='\n')
 
-    formatDoc :: [Diff String] -> String
+    formatDoc :: [Diff T.Text] -> T.Text
     formatDoc [] = ""
-    formatDoc (Both l _:d)  =           " " ++ l ++      "\n" ++ formatDoc d
-    formatDoc (First l:d)   = "\27[1;31m-" ++ l ++ "\27[0m\n" ++ formatDoc d
-    formatDoc (Second l:d)  = "\27[1;32m+" ++ l ++ "\27[0m\n" ++ formatDoc d
+    formatDoc (Both l _:d)  =          " " <> l <>       "\n" <> formatDoc d
+    formatDoc (First l:d)   = "\27[1;31m-" <> l <> "\27[0m\n" <> formatDoc d
+    formatDoc (Second l:d)  = "\27[1;32m+" <> l <> "\27[0m\n" <> formatDoc d
 
-goldenFile :: (FilePath -> T.Text -> String) -> FilePath -> String -> String -> TestTree
+goldenFile :: (FilePath -> T.Text -> T.Text) -> FilePath -> String -> String -> TestTree
 goldenFile fn dir name out = testCase name $ do
   actual <- fn name <$> T.readFile (dir ++ name)
   golden (dir ++ out) actual
 
-goldenDirOn :: (FilePath -> T.Text -> String) -> (String -> String) -> FilePath -> String -> IO [TestTree]
+goldenDirOn :: (FilePath -> T.Text -> T.Text) -> (String -> String) -> FilePath -> String -> IO [TestTree]
 goldenDirOn fn out dir ext = mapMaybe (\x -> goldenFile fn dir x . out <$> spanTail ext x) . sort <$> listDirectory dir where
   spanTail _ [] = Nothing
   spanTail s x@(y:ys) = if x == s then Just [] else (y:) <$> spanTail s ys
 
-goldenDir :: (FilePath -> T.Text -> String) -> FilePath -> String -> IO [TestTree]
+goldenDir :: (FilePath -> T.Text -> T.Text) -> FilePath -> String -> IO [TestTree]
 goldenDir = flip goldenDirOn (++".out")

--- a/src/Backend/Lua/Syntax.hs
+++ b/src/Backend/Lua/Syntax.hs
@@ -6,7 +6,7 @@ module Backend.Lua.Syntax
   , keywords
   ) where
 
-import Pretty
+import Text.Pretty.Semantic
 
 import qualified Data.Set as Set
 import qualified Data.Text as T

--- a/src/Control/Monad/Infer.hs
+++ b/src/Control/Monad/Infer.hs
@@ -45,7 +45,7 @@ import Data.Maybe
 import Data.Text (Text)
 import Data.List
 
-import Pretty
+import Text.Pretty.Semantic
 
 import Syntax.Pretty
 import Syntax.Types

--- a/src/Control/Monad/Infer/Error.hs
+++ b/src/Control/Monad/Infer/Error.hs
@@ -8,7 +8,7 @@ import Data.Span
 import Data.Data
 
 import Syntax.Pretty
-import Pretty
+import Text.Pretty.Semantic
 
 data SomeReason where
   BecauseOf :: (Reasonable a p) => a p -> SomeReason

--- a/src/Core/Core.hs
+++ b/src/Core/Core.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE PatternSynonyms, TemplateHaskell #-}
 module Core.Core where
 
-import Pretty
+import Text.Pretty.Semantic
 
 import qualified Data.VarSet as VarSet
 import Data.Function

--- a/src/Core/Lint.hs
+++ b/src/Core/Lint.hs
@@ -21,7 +21,7 @@ import Data.List
 import Core.Optimise
 import Core.Builtin
 import Core.Types
-import Pretty hiding ((<>))
+import Text.Pretty.Semantic hiding ((<>))
 
 data CoreError a
   = TypeMismatch (Type a) (Type a)

--- a/src/Core/Lint.hs
+++ b/src/Core/Lint.hs
@@ -11,6 +11,7 @@ import Control.Monad.Except
 
 import qualified Data.VarMap as VarMap
 import qualified Data.VarSet as VarSet
+import qualified Data.Text as T
 import Data.Traversable
 import Data.Foldable
 import Data.Function
@@ -76,10 +77,11 @@ runLint m a =
               Right _ -> es
   in case es' of
        [] -> a
-       es' -> error $ renderDetailed $ string "Core lint failed:" <#>
-                                       prettyList es' <#>
-                                       string "for term" <#>
-                                       pretty a
+       es' -> error . T.unpack . displayDetailed $
+              string "Core lint failed:" <#>
+              prettyList es' <#>
+              string "for term" <#>
+              pretty a
 
 runLintOK :: IsVar a => ExceptT (CoreError a) (Writer [CoreError a]) () -> Either [CoreError a] ()
 runLintOK m = case runWriter (runExceptT m) of

--- a/src/Core/Lower.hs
+++ b/src/Core/Lower.hs
@@ -37,7 +37,7 @@ import qualified Syntax as S
 import Syntax.Let
 import Syntax (Var(..), Resolved, Typed, Expr(..), Pattern(..), Lit(..), Skolem(..), Toplevel(..), Constructor(..))
 
-import Pretty (pretty)
+import Text.Pretty.Semantic (pretty)
 
 type Atom = C.Atom CoVar
 type Term = C.Term CoVar

--- a/src/Core/Occurrence.hs
+++ b/src/Core/Occurrence.hs
@@ -19,7 +19,7 @@ import Data.Triple
 import Data.Maybe
 import Data.Data
 
-import Pretty
+import Text.Pretty.Semantic
 
 data Occurrence = Dead | Once | OnceLambda | Multi | MultiLambda
   deriving (Show, Eq, Ord, Data)

--- a/src/Core/Var.hs
+++ b/src/Core/Var.hs
@@ -5,7 +5,7 @@ module Core.Var where
 import qualified Data.Text as T
 import Control.Lens
 import GHC.Generics
-import Pretty
+import Text.Pretty.Semantic
 import Data.Data
 
 data CoVar =

--- a/src/Data/Span.hs
+++ b/src/Data/Span.hs
@@ -9,7 +9,7 @@ module Data.Span
   , spanEnd
   ) where
 
-import Pretty
+import Text.Pretty.Semantic
 
 import Data.Data
 import Data.Position

--- a/src/Parser/Error.hs
+++ b/src/Parser/Error.hs
@@ -9,7 +9,7 @@ import Data.Span
 import Data.Char
 
 import Parser.Token
-import Pretty
+import Text.Pretty.Semantic
 
 data ParseError
   = Failure SourcePos String

--- a/src/Parser/Wrapper.hs
+++ b/src/Parser/Wrapper.hs
@@ -34,7 +34,7 @@ import Parser.Context
 import Parser.Token
 import Parser.Error
 
-import Pretty
+import Text.Pretty.Semantic
 
 
 data AlexInput = LI { liPos  :: !SourcePos

--- a/src/Syntax/Pretty.hs
+++ b/src/Syntax/Pretty.hs
@@ -14,7 +14,7 @@ import Data.Span
 
 import Syntax.Subst
 import Syntax
-import Pretty
+import Text.Pretty.Semantic
 
 parenFun :: Pretty (Var p) => Expr p -> Doc
 parenFun f = case f of

--- a/src/Syntax/Resolve.hs
+++ b/src/Syntax/Resolve.hs
@@ -37,7 +37,7 @@ import Syntax.Resolve.Toplevel
 import Syntax.Pretty
 import Syntax.Subst
 
-import Pretty
+import Text.Pretty.Semantic
 
 data ResolveError
   = NotInScope (Var Parsed)

--- a/src/Text/Pretty.hs
+++ b/src/Text/Pretty.hs
@@ -3,15 +3,17 @@ module Text.Pretty
   ( module Text.PrettyPrint.Annotated.Leijen
   , (<>), (<#>), (<##>)
   , text, shown
+  , filterSimpleDoc
+  , display
   , bullet
   ) where
 
+import qualified Data.Text.Lazy.Builder as B
+import qualified Data.Text.Lazy as L
+import qualified Data.Text as T
 
 import qualified Text.PrettyPrint.Annotated.Leijen as P
-import Text.PrettyPrint.Annotated.Leijen hiding (text, (<>), (<$>), (<$$>))
-
-import qualified Data.Text as T
-import Data.Text (Text)
+import Text.PrettyPrint.Annotated.Leijen hiding (text, display, (<>), (<$>), (<$$>))
 
 instance Semigroup (Doc a) where
   (<>) = (P.<>)
@@ -27,11 +29,42 @@ infixr 5 <#>,<##>
 (<#>) = (P.<$>)
 (<##>) = (P.<$$>)
 
-text :: Text -> Doc a
+text :: T.Text -> Doc a
 text = string . T.unpack
 
 shown :: Show b => b -> Doc a
 shown = string . show
 
 bullet :: Doc a -> Doc a
-bullet = (char '·'<+>)
+bullet = (char '•'<+>)
+
+filterSimpleDoc :: (a -> Bool) -> SimpleDoc a -> SimpleDoc a
+filterSimpleDoc f = go where
+  go SEmpty              = SEmpty
+  go (SChar c x)         = SChar c (go x)
+  go (SText l str x)     = SText l str (go x)
+  go (SLine ind x)       = SLine ind (go x)
+  go (SAnnotStart ann x) = if f ann then SAnnotStart ann (go x) else discard (0 :: Int) x
+  go (SAnnotStop x)      = SAnnotStop (go x)
+
+  discard _ SEmpty            = error "Unexpected empty"
+  discard n (SChar _ x)       = discard n x
+  discard n (SText _ _ x)     = discard n x
+  discard n (SLine _ x)       = discard n x
+  discard n (SAnnotStart _ x) = discard (n + 1) x
+  discard n (SAnnotStop x)    | n == 0 = go x
+                              | otherwise = discard (n - 1) x
+
+--- Mostly the same as normal display, but emitting text and avoiding trailing whitespace on blank lines
+display :: SimpleDoc a -> T.Text
+display = L.toStrict . B.toLazyText . go where
+  go SEmpty              = mempty
+  go (SChar c x)         = B.singleton c <> go x
+  go (SText _ str x)     = B.fromString str <> go x
+  go (SLine _ x@SLine{}) = B.singleton '\n' <> go x
+  go (SLine ind x)       = B.singleton '\n' <> indentation ind <> go x
+  go (SAnnotStart _ x)   = go x
+  go (SAnnotStop x)      = go x
+
+  indentation n | n <= 0 = mempty
+                | otherwise = B.fromLazyText (L.replicate (fromIntegral n) (L.singleton ' '))

--- a/src/Text/Pretty.hs
+++ b/src/Text/Pretty.hs
@@ -1,0 +1,37 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Text.Pretty
+  ( module Text.PrettyPrint.Annotated.Leijen
+  , (<>), (<#>), (<##>)
+  , text, shown
+  , bullet
+  ) where
+
+
+import qualified Text.PrettyPrint.Annotated.Leijen as P
+import Text.PrettyPrint.Annotated.Leijen hiding (text, (<>), (<$>), (<$$>))
+
+import qualified Data.Text as T
+import Data.Text (Text)
+
+instance Semigroup (Doc a) where
+  (<>) = (P.<>)
+
+instance Monoid (Doc a) where
+  mempty = P.empty
+  mappend = (P.<>)
+
+infixr 5 <#>,<##>
+
+-- Alias various definitions so we're not masking existing definitions
+(<#>), (<##>) :: Doc a -> Doc a -> Doc a
+(<#>) = (P.<$>)
+(<##>) = (P.<$$>)
+
+text :: Text -> Doc a
+text = string . T.unpack
+
+shown :: Show b => b -> Doc a
+shown = string . show
+
+bullet :: Doc a -> Doc a
+bullet = (char '·'<+>)

--- a/src/Text/Pretty/Ansi.hs
+++ b/src/Text/Pretty/Ansi.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE FlexibleContexts, OverloadedStrings #-}
+module Text.Pretty.Ansi
+  ( Colour(..)
+  , AnsiStyle (..)
+  , putDoc, putDocWithoutColour, hPutDoc, render
+  , displayDecorated
+  ) where
+
+import qualified Data.Text.Lazy.Builder.Int as B
+import qualified Data.Text.Lazy.Builder as B
+import qualified Data.Text.Lazy as L
+import qualified Data.Text.IO as T
+import qualified Data.Text as T
+import Data.Maybe
+
+import Text.Pretty hiding (putDoc, displayDecorated, hPutDoc)
+
+import System.IO (Handle, stdout)
+
+data Colour = Black | Red | Green | Yellow | Blue | Magenta | Cyan | White
+  deriving (Show, Eq, Ord, Enum)
+
+data AnsiStyle
+  = Unstyled
+  | DullColour Colour
+  | BrightColour Colour
+  | Underlined
+  deriving (Show, Eq, Ord)
+
+data TermState = TS { colour    :: Maybe Colour
+                    , bold      :: Bool
+                    , underline :: Bool
+                    }
+  deriving (Show, Eq)
+
+putDoc :: Doc AnsiStyle -> IO ()
+putDoc = hPutDoc stdout
+
+putDocWithoutColour :: Doc AnsiStyle -> IO ()
+putDocWithoutColour = T.putStrLn . display . renderPretty 0.4 100
+
+hPutDoc :: Handle -> Doc AnsiStyle -> IO ()
+hPutDoc h = T.hPutStrLn h . displayDecorated . renderPretty 0.4 100
+
+render :: Doc AnsiStyle -> T.Text
+render = displayDecorated . renderPretty 0.4 100
+
+displayDecorated :: SimpleDoc AnsiStyle -> T.Text
+displayDecorated = L.toStrict . B.toLazyText . go [TS Nothing False False] where
+  genDelta :: TermState -> TermState -> [Int]
+  genDelta f@(TS fc fb fu) t@(TS tc tb tu)
+    -- Identical states require no difference
+    | f == t = mempty
+    -- If we went from bold to not bold, underlined to not underlined
+    -- or from coloured to normal, then reset our state and continue.
+    | (fb && not tb) ||
+      (fu && not tu) ||
+      (isJust fc && isNothing tc)
+    = [0] ++ [ 4 | tu ] ++ [ 1 | tb ] ++
+      maybe [] (pure . (+30) . fromEnum) tc
+    -- Otherwise just emit the delta
+    | otherwise
+    = [ 4 | tu && not fu ] ++ [ 1 | tb && not fb ] ++
+      [ 30 + fromEnum (fromJust (colour t)) | fc /= tc ]
+
+  appAnn :: TermState -> AnsiStyle -> TermState
+  appAnn s Unstyled         = s
+  appAnn s Underlined       = s { underline = True }
+  appAnn s (BrightColour c) = s { bold = True,  colour = Just c }
+  appAnn s (DullColour c)   = s { bold = False, colour = Just c }
+
+  toAnsi [] = mempty
+  toAnsi xs = "\x1b[" <> go xs <> B.singleton 'm' where
+    go [] = undefined
+    go [x] = B.decimal x
+    go (x:xs) = B.decimal x <> B.singleton ';' <> go xs
+
+  go :: [TermState] -> SimpleDoc AnsiStyle -> B.Builder
+  go [_]       SEmpty              = mempty
+  go stk       (SChar c x)         = B.singleton c <> go stk x
+  go stk       (SText _ str x)     = B.fromString str <> go stk x
+  go stk       (SLine _ x@SLine{}) = B.singleton '\n' <> go stk x
+  go stk       (SLine ind x)       = B.singleton '\n' <> indentation ind <> go stk x
+  go stk@(p:_) (SAnnotStart ann x) = let n = appAnn p ann
+                                     in toAnsi (genDelta p n) <> go (n:stk) x
+  go (n:p:stk) (SAnnotStop x)      = toAnsi (genDelta n p) <> go (p:stk) x
+
+  -- malformed documents
+  go _ SAnnotStop{} = error "stack underflow"
+  go _ SAnnotStart{} = error "stack underflow"
+  go s SEmpty = error ("stack not consumed by rendering (" ++ show s ++ ")")
+
+  indentation n | n <= 0 = mempty
+                | otherwise = B.fromLazyText (L.replicate (fromIntegral n) (L.singleton ' '))

--- a/src/Text/Pretty/Semantic.hs
+++ b/src/Text/Pretty/Semantic.hs
@@ -1,39 +1,26 @@
-{-# OPTIONS_GHC -Wno-orphans #-}
 {-# LANGUAGE FlexibleInstances, GADTs #-}
-module Pretty
-  ( module Text.PrettyPrint.Annotated.Leijen
+module Text.Pretty.Semantic
+  ( module Text.Pretty
   , Style
   , Pretty(..)
   , Doc
-  , (<>), (<#>), (<##>)
   , putDoc, putDocWithoutColour, hPutDoc
   , render, renderDetailed
   , decorate, decorateDetailed, decoratePlain
-  , text, shown
   , skeyword, sliteral, sstring, scomment, stypeCon, stypeVar, stypeSkol, soperator
 
   , arrow, equals, colon, prod, pipe
   , keyword, highlight
-  , verbatim, bullet
+  , verbatim
   ) where
 
 
-import qualified Text.PrettyPrint.Annotated.Leijen as P
-import Text.PrettyPrint.Annotated.Leijen hiding (text, hPutDoc, putDoc, Doc, equals, colon, pipe, (<>), (<$>), (<$$>))
+import qualified Text.Pretty as P
+import Text.Pretty hiding (hPutDoc, putDoc, Doc, equals, colon, pipe)
 
 import System.IO (hPutStrLn, Handle, stdout)
 
-import qualified Data.Text as T
-import Data.Text (Text)
-
 type Doc = P.Doc Style
-
-instance Semigroup (P.Doc a) where
-  (<>) = (P.<>)
-
-instance Monoid (P.Doc a) where
-  mempty = P.empty
-  mappend = (P.<>)
 
 class Pretty a where
   pretty :: a -> Doc
@@ -53,19 +40,6 @@ data Style
 
   | Operator
   deriving (Eq, Show, Ord)
-
-infixr 5 <#>,<##>
-
--- Alias various definitions so we're not masking existing definitions
-(<#>), (<##>) :: P.Doc a -> P.Doc a -> P.Doc a
-(<#>) = (P.<$>)
-(<##>) = (P.<$$>)
-
-text :: Text -> Doc
-text = string . T.unpack
-
-shown :: Show a => a -> Doc
-shown = string . show
 
 putDoc :: Doc -> IO ()
 putDoc = hPutDoc stdout
@@ -136,6 +110,3 @@ highlight = stypeSkol . string
 
 verbatim :: Pretty a => a -> Doc
 verbatim = enclose (char '`') (char '`') . pretty
-
-bullet :: Doc -> Doc
-bullet = (char '·' <+>)

--- a/src/Types/Infer.hs
+++ b/src/Types/Infer.hs
@@ -38,7 +38,7 @@ import Types.Infer.Builtin
 import Types.Wellformed
 import Types.Unify
 
-import Pretty
+import Text.Pretty.Semantic
 
 -- Solve for the types of lets in a program
 inferProgram :: MonadGen Int m => Env -> [Toplevel Resolved] -> m (Either TypeError ([Toplevel Typed], Env))

--- a/src/Types/Infer/Builtin.hs
+++ b/src/Types/Infer/Builtin.hs
@@ -15,7 +15,7 @@ import Control.Lens
 import Syntax.Types
 import Syntax
 
-import Pretty
+import Text.Pretty.Semantic
 
 tyUnit, tyBool, tyInt, tyString, tyFloat, tyAny :: Type Typed
 tyInt = TyCon (TvName (TgInternal "int"))

--- a/src/Types/Infer/Errors.hs
+++ b/src/Types/Infer/Errors.hs
@@ -12,7 +12,7 @@ import Syntax.Transform
 import Syntax.Subst
 import Syntax.Pretty
 
-import Pretty
+import Text.Pretty.Semantic
 
 gadtConShape :: (Type Typed, Type Typed) -> Type Typed -> TypeError -> TypeError
 gadtConShape (t, _) (TyArr c d) oerr = k . fix . flip Note (string "Generalised constructors can not be curried") $ err where

--- a/src/Types/Kinds.hs
+++ b/src/Types/Kinds.hs
@@ -29,7 +29,7 @@ import Syntax.Subst
 import Syntax.Raise
 import Syntax
 
-import Pretty
+import Text.Pretty.Semantic
 
 type KindT m = StateT SomeReason (WriterT (Seq.Seq (Constraint Typed)) m)
 

--- a/tests/gadt/fail_term.out
+++ b/tests/gadt/fail_term.out
@@ -1,12 +1,12 @@
 fail_term.ml[16:3 ..16:30]: error
   Could not match rigid type variable b with the rigid type variable a
-  · Note: the variable b was rigidified because of a type ascription
+  • Note: the variable b was rigidified because of a type ascription
   against the type {'a : type}. {'b : type}. term unit ('a -> 'b -> 'b)
           and is represented by the constant ph
-  
-  · Note: the rigid type variable a, in turn,
+
+  • Note: the rigid type variable a, in turn,
           was rigidified because of a type ascription
   against the type {'a : type}. {'b : type}. term unit ('a -> 'b -> 'b)
           and is represented by the constant pg
-  
+
   Arising from use of the expression

--- a/tests/gadt/gadt01.out
+++ b/tests/gadt/gadt01.out
@@ -1,5 +1,5 @@
 gadt01.ml[3:16 ..3:20]: error
   Could not match type type with 'e -> type
   Have you applied a type constructor to the wrong number of arguments?
-  
+
   Arising from use of the declaration

--- a/tests/gadt/gadt02.out
+++ b/tests/gadt/gadt02.out
@@ -1,8 +1,8 @@
 gadt02.ml[7:5 ..7:23]: error
   The type `t2 int -> t2 bool` is malformed.
-  · Note: The type t2 bool is not an instance of the type being declared
-  · Note: It must end in an application like t1 'a
+  • Note: The type t2 bool is not an instance of the type being declared
+  • Note: It must end in an application like t1 'a
             but it ends in an application of some other type
-  · Suggestion: did you mean t1 bool instead of t2 bool?
-  
+  • Suggestion: did you mean t1 bool instead of t2 bool?
+
   Arising from use of the constructor

--- a/tests/gadt/gadt03-fail.out
+++ b/tests/gadt/gadt03-fail.out
@@ -1,4 +1,4 @@
 gadt03-fail.ml[7:12 ..7:12]: error
   Could not match type int with bool
-  
+
   Arising from use of the expression

--- a/tests/gadt/gadt04-pass.out
+++ b/tests/gadt/gadt04-pass.out
@@ -1,6 +1,6 @@
 gadt04-pass.ml[2:5 ..2:27]: error
   The type `int -> int -> t` is malformed.
-  · Note: Generalised constructors can not be curried
-  · Suggestion: Perhaps use a tuple: `(int * int) -> t`
-  
+  • Note: Generalised constructors can not be curried
+  • Suggestion: Perhaps use a tuple: `(int * int) -> t`
+
   Arising from use of the constructor

--- a/tests/gadt/gadt07-escape-fail.out
+++ b/tests/gadt/gadt07-escape-fail.out
@@ -1,8 +1,8 @@
 gadt07-escape-fail.ml[10:3 ..10:14]: error
   Could not match rigid type variable a with the type int
-  · Note: the variable a was rigidified because it is an existential,
+  • Note: the variable a was rigidified because it is an existential,
   bound by the type of MkHid, (exp 'a * exp 'a) -> hidden
           and is represented by the constant cp
-  
-  
+
+
   Arising from use of the expression

--- a/tests/rankn/impredicative01-fail.out
+++ b/tests/rankn/impredicative01-fail.out
@@ -1,7 +1,7 @@
 impredicative01-fail.ml[3:5 ..3:34]: error
   Illegal use of polymorphic type `{'a : 'n}. 'a`
     as argument to the type function `foo`
-  · Note: instantiating a type variable (the argument to `foo`)
+  • Note: instantiating a type variable (the argument to `foo`)
     with a polymorphic type constitutes impredicative polymorphism
-  
+
   Arising from use of the declaration

--- a/tests/resolve/fail_let_ambiguity.out
+++ b/tests/resolve/fail_let_ambiguity.out
@@ -1,4 +1,4 @@
 fail_let_ambiguity.ml[6:18 ..6:18]: error
   Ambiguous reference to variable: `y`
-  
+
   Arising from use of the expression y

--- a/tests/resolve/fail_modules.out
+++ b/tests/resolve/fail_modules.out
@@ -1,4 +1,4 @@
 fail_modules.ml[4:9 ..4:9]: error
   Variable not in scope: `x`
-  
+
   Arising from use of the expression x

--- a/tests/resolve/fail_pattern_ambiguity.out
+++ b/tests/resolve/fail_pattern_ambiguity.out
@@ -1,12 +1,12 @@
 fail_pattern_ambiguity.ml[2:3 ..2:8]: error
   Non-linear pattern (multiple definitions of `a#2` )
-  
+
   Arising from use of the pattern (a, a)
 fail_pattern_ambiguity.ml[2:13 ..2:13]: error
   Ambiguous reference to variable: `a`
-  
+
   Arising from use of the expression a
 fail_pattern_ambiguity.ml[2:17 ..2:17]: error
   Ambiguous reference to variable: `a`
-  
+
   Arising from use of the expression a

--- a/tests/types/fail_skolem_escape.out
+++ b/tests/types/fail_skolem_escape.out
@@ -1,10 +1,10 @@
 fail_skolem_escape.ml[2:19 ..2:38]: error
   Rigid type variable a has escaped its scope of {'a : type}. 'a -> 'o
-  · Note: the variable a was rigidified because of a type ascription
+  • Note: the variable a was rigidified because of a type ascription
           against the type {'a : type}. 'a -> 'o,
           and is represented by constant aw
-  
-  · Note: in type `aw`
-  · Note: in the inferred type for escape_fail
-  
+
+  • Note: in type `aw`
+  • Note: in the inferred type for escape_fail
+
   Arising from use of the expression

--- a/tests/types/fail_skolem_poly.out
+++ b/tests/types/fail_skolem_poly.out
@@ -1,8 +1,8 @@
 fail_skolem_poly.ml[2:32 ..2:32]: error
   Could not match rigid type variable a with the type int
-  · Note: the variable a was rigidified because of a type ascription
+  • Note: the variable a was rigidified because of a type ascription
   against the type {'a : type}. 'a -> 'a
           and is represented by the constant aq
-  
-  
+
+
   Arising from use of the expression

--- a/tests/types/fail_skolem_pure.out
+++ b/tests/types/fail_skolem_pure.out
@@ -1,8 +1,8 @@
 fail_skolem_pure.ml[2:32 ..2:32]: error
   Could not match rigid type variable a with the type 'f bq
-  · Note: the variable a was rigidified because of a type ascription
+  • Note: the variable a was rigidified because of a type ascription
   against the type {'a : type}. 'a -> 'f 'a
           and is represented by the constant bq
-  
-  
+
+
   Arising from use of the expression


### PR DESCRIPTION
This separates the construction of "semantically annotated" documents from their rendering into ANSI strings. This brings several advantages:

 - Some operations are now generalised over all documents, not just `Doc Style` ones.
 - Our ANSI renderer can be smarter than the previous "concat everything together" one was. For instance, nested annotations now render as expected.

The other major change here is converting the pretty printer to produce `Text` instead of `String`s.

I apologise for the rather noisy PR - moving the package, fixing trailing whitespace and changing the bullet meant a lot of files have a single line diff.