### PR TITLE
Report Many Type Errors

### DIFF
--- a/compiler/Errors.hs
+++ b/compiler/Errors.hs
@@ -24,6 +24,7 @@ report :: Pretty p => p -> FileMap -> IO ()
 report err _ = putDoc (pretty err)
 
 reportI :: I.TypeError -> FileMap -> IO ()
+reportI (I.ManyErrors errs) files = traverse_ (flip reportI files) errs
 reportI err files
   | (err', Just (reason, loc)) <- innermostError err
   = reportP (I.ArisingFrom err' reason) loc files

--- a/compiler/Test/Types/Check.hs
+++ b/compiler/Test/Types/Check.hs
@@ -34,11 +34,12 @@ result file contents = runGen $ do
   inferred <- inferProgram builtinsEnv desugared
 
   pure . display . simplifyDoc . renderPretty 0.8 120 . (<##>empty)
-       . either (pretty . reportT) (reportEnv . snd) $ inferred
+       . either reportT (reportEnv . snd) $ inferred
 
   where
-    reportT :: TypeError -> TypeError
-    reportT err = fromMaybe err (innermostError err)
+    reportT :: TypeError -> Doc
+    reportT (ManyErrors es) = vsep (map reportT es)
+    reportT err = pretty (fromMaybe err (innermostError err))
 
     reportEnv env =
       let env' = difference env builtinsEnv

--- a/src/Control/Monad/Infer.hs
+++ b/src/Control/Monad/Infer.hs
@@ -57,7 +57,7 @@ data Constraint p
   = ConUnify   SomeReason (Var p)  (Type p) (Type p)
   | ConSubsume SomeReason (Var p)  (Type p) (Type p)
   | ConImplies SomeReason (Type p) (Seq.Seq (Constraint p)) (Seq.Seq (Constraint p))
-  | ConFail (Var p) (Type p) -- for holes. I hate it.
+  | ConFail (Ann p) (Var p) (Type p) -- for holes. I hate it.
 
 deriving instance (Show (Ann p), Show (Var p), Show (Expr p), Show (Type p))
   => Show (Constraint p)
@@ -99,12 +99,12 @@ instance (Ord (Var p), Substitutable p (Type p)) => Substitutable p (Constraint 
   ftv (ConUnify _ _ a b) = ftv a `Set.union` ftv b
   ftv (ConSubsume _ _ a b) = ftv a `Set.union` ftv b
   ftv (ConImplies _ t a b) = ftv a `Set.union` ftv b `Set.union` ftv t
-  ftv (ConFail _ t) = ftv t
+  ftv (ConFail _ _ t) = ftv t
 
   apply s (ConUnify e v a b) = ConUnify e v (apply s a) (apply s b)
   apply s (ConSubsume e v a b) = ConSubsume e v (apply s a) (apply s b)
   apply s (ConImplies e t a b) = ConImplies e (apply s t) (apply s a) (apply s b)
-  apply s (ConFail e t) = ConFail e (apply s t)
+  apply s (ConFail a e t) = ConFail a e (apply s t)
 
 instance Pretty (Var p) => Pretty (Constraint p) where
   pretty (ConUnify _ _ a b) = pretty a <+> soperator (char '~') <+> pretty b

--- a/src/Types/Infer.hs
+++ b/src/Types/Infer.hs
@@ -50,7 +50,7 @@ check e ty@TyForall{} = do -- This is rule Decl∀L from [Complete and Easy]
   pure (ExprWrapper wrap e (annotation e, ty))
 
 check (Hole v a) t = do
-  tell (Seq.singleton (ConFail (TvName v) t))
+  tell (Seq.singleton (ConFail (a, t) (TvName v) t))
   pure (Hole (TvName v) (a, t))
 
 check (Begin [] _) _ = error "impossible: check empty Begin"

--- a/src/Types/Unify.hs
+++ b/src/Types/Unify.hs
@@ -23,6 +23,8 @@ import Data.Function
 import Data.List
 import Data.Text (Text)
 
+import Debug.Trace
+
 data SolveScope
   = SolveScope { _bindSkol :: Bool
                , _don'tTouch :: Set.Set (Var Typed)
@@ -241,10 +243,11 @@ doSolve (ConImplies because not cs ts :<| xs) = do
     solveAssumptions .= assump
 
     doSolve xs
-doSolve (ConFail v t :<| cs) = do
+doSolve (ConFail a v t :<| cs) = do
   doSolve cs
   sub <- use solveTySubst
-  tell [foundHole v (apply sub t) sub]
+  let ex = Hole (unTvName v) (fst a)
+  tell [propagateBlame (BecauseOf ex) $ foundHole v (apply sub t) sub]
 
 subsumes :: (Type Typed -> Type Typed -> SolveM (Coercion Typed))
          -> Type Typed -> Type Typed -> SolveM (Wrapper Typed)

--- a/src/Types/Unify.hs
+++ b/src/Types/Unify.hs
@@ -244,7 +244,7 @@ doSolve (ConImplies because not cs ts :<| xs) = do
 doSolve (ConFail v t :<| cs) = do
   doSolve cs
   sub <- use solveTySubst
-  throwError (foundHole v (apply sub t) sub)
+  tell [foundHole v (apply sub t) sub]
 
 subsumes :: (Type Typed -> Type Typed -> SolveM (Coercion Typed))
          -> Type Typed -> Type Typed -> SolveM (Wrapper Typed)

--- a/src/Types/Unify.hs
+++ b/src/Types/Unify.hs
@@ -23,8 +23,6 @@ import Data.Function
 import Data.List
 import Data.Text (Text)
 
-import Debug.Trace
-
 data SolveScope
   = SolveScope { _bindSkol :: Bool
                , _don'tTouch :: Set.Set (Var Typed)

--- a/tests/types/fail_skolem_poly.out
+++ b/tests/types/fail_skolem_poly.out
@@ -6,3 +6,11 @@ fail_skolem_poly.ml[2:32 ..2:32]: error
 
 
   Arising from use of the expression
+fail_skolem_poly.ml[2:32 ..2:36]: error
+  Could not match rigid type variable a with the type int
+  • Note: the variable a was rigidified because of a type ascription
+  against the type {'a : type}. 'a -> 'a
+          and is represented by the constant aq
+
+
+  Arising from use of the expression


### PR DESCRIPTION
While type checking depends on the structure of the code, solving is mostly independent (other than the tree structured imposed by implication constraints).

It's also _mostly_ independent of order: we can keep solving constraints, even after one fails.

This patch does just that - try to solve _all_ constraints, and then report all errors that arose.