### PR TITLE
Feature: Visible Quantification

### DIFF
--- a/compiler/Test/Types/Check.hs
+++ b/compiler/Test/Types/Check.hs
@@ -51,4 +51,5 @@ tests = do
   inference <- testGroup "Type inference tests" <$> goldenDir result "tests/types/" ".ml"
   gadts <- testGroup "GADT inference tests" <$> goldenDir result "tests/gadt/" ".ml"
   rankn <- testGroup "Rank-N inference tests" <$> goldenDir result "tests/rankn/" ".ml"
-  pure (testGroup "Type inference" [ inference, gadts, rankn ])
+  visinst <- testGroup "Visible Instantiation inference tests" <$> goldenDir result "tests/visinst/" ".ml"
+  pure (testGroup "Type inference" [ inference, gadts, rankn, visinst ])

--- a/src/Control/Monad/Infer.hs
+++ b/src/Control/Monad/Infer.hs
@@ -94,6 +94,10 @@ data TypeError where
 
   Malformed :: Pretty (Var p) => Type p -> TypeError
 
+  -- Mismatched quantification
+  VisibleExpr :: (Pretty (Var p), Pretty (Var p')) => Expr p' -> Type p -> TypeError
+  AnonType :: Pretty (Var p) => Type p -> Type p -> TypeError
+
   NotPromotable :: Pretty (Var p) => Var p -> Type p -> Doc -> TypeError
   ManyErrors :: [TypeError] -> TypeError
 
@@ -277,6 +281,11 @@ instance Pretty TypeError where
     where whatIs (TySkol (Skolem _ v _ _)) = string "the rigid type variable" <+> stypeVar (pretty v)
           whatIs t = string "the type" <+> pretty t
           skol = stypeVar (pretty v)
+
+  pretty (VisibleExpr e ty) =
+    vsep [ string "Expression" <+> pretty e <+> "given as argument to function of type" <+> pretty ty ]
+  pretty (AnonType t ty) =
+    vsep [ string "Type" <+> pretty t <+> "given as argument to function of type" <+> pretty ty ]
 
 instance Spanned TypeError where
   annotation (ArisingFrom e@ArisingFrom{} _) = annotation e

--- a/src/Control/Monad/Infer.hs
+++ b/src/Control/Monad/Infer.hs
@@ -290,9 +290,23 @@ instance Pretty TypeError where
          , note <+> "You can use a hole like"
              <+> pretty ((InstHole undefined) :: Expr Typed) <+> "to make the compiler infer this"
          ]
-  pretty (WrongQuantifier (InstType t _) ty@TyArr{}) =
-    vsep [ string "Type" <+> pretty t <+> "given as argument to function of type" <+> pretty ty ]
-  pretty WrongQuantifier{} = error "WrongQuantifier wrong"
+  pretty (WrongQuantifier t ty@TyArr{}) =
+    vsep [ thing <+> "given as argument to function of type" <+> pretty ty
+         , string "Have you applied a function to the wrong number of arguments?"
+         ] where
+      thing = case t of
+        InstHole{} -> highlight "Hole" <+> pretty t
+        InstType{} -> highlight "Type" <+> pretty t
+        _ -> error "WrongQuantifier wrong"
+  pretty (WrongQuantifier t ty) =
+    vsep [ thing <+> "given as argument to expression of type" <+> pretty ty
+         , string "Have you applied a function to too many arguments?"
+         ] where
+      thing = case t of
+        InstHole{} -> highlight "Hole" <+> pretty t
+        InstType{} -> highlight "Type" <+> pretty t
+        _ -> highlight "Expression"
+
 
   pretty (NakedInstArtifact h@InstHole{}) =
     vsep [ string "Instantiation hole" <+> pretty h <+> "used outside of type application" ]

--- a/src/Control/Monad/Infer.hs
+++ b/src/Control/Monad/Infer.hs
@@ -211,7 +211,7 @@ instance Pretty TypeError where
   pretty (ArisingFrom er ex) = pretty er <#> empty <#> nest 4 (string "Arising in" <+> blameOf ex)
   pretty (FoundHole e s) = string "Found typed hole" <+> pretty e <+> "of type" <+> pretty s
 
-  pretty (Note te m) = pretty te <#> bullet (string "Note:") <+> align (pretty m)
+  pretty (Note te m) = pretty te <#> note <+> align (pretty m)
   pretty (Suggestion te m) = pretty te <#> bullet (string "Suggestion:") <+> align (pretty m)
   pretty (CanNotInstance rec new) = string "Can not instance hole of record type" <+> align (verbatim rec </> string " to type " <+> verbatim new)
   pretty (Malformed tp) = string "The type" <+> verbatim tp <+> string "is malformed."
@@ -236,13 +236,13 @@ instance Pretty TypeError where
   pretty (Impredicative v t)
     = vsep [ string "Illegal instantiation of type variable" <+> stypeVar (pretty v)
            , indent 16 (string "with polymorphic type" <+> verbatim t)
-           , bullet (string "Note:") <+> string "doing so would constitute" <+> stypeCon (string "impredicative polymorphism")
+           , note <+> string "doing so would constitute" <+> stypeCon (string "impredicative polymorphism")
            ]
 
   pretty (ImpredicativeApp tf tx)
     = vsep [ string "Illegal use of polymorphic type" <+> verbatim tx
            , indent 2 $ string "as argument to the type function" <+> verbatim tf
-           , bullet (string "Note:") <+> string "instantiating a type variable"
+           , note <+> string "instantiating a type variable"
            <+> nest 2 (parens (string "the argument to" <+> verbatim tf)
                    </> string "with a polymorphic type constitutes" <+> stypeCon (string "impredicative polymorphism"))
            ]
@@ -252,29 +252,29 @@ instance Pretty TypeError where
             [Skolem{..}] ->
               let skol = stypeVar (pretty _skolVar) in
               string "Rigid type variable" <+> skol <+> string "has escaped its scope of" <+> pretty _skolScope
-                  <#> bullet (string "Note: the variable") <+> skol <+> string "was rigidified because"
+                  <#> note <+> string "the variable" <+> skol <+> string "was rigidified because"
                         <+> nest 8 (prettyMotive _skolMotive <> comma)
                   <#> indent 8 (string "and is represented by constant" <+> stypeSkol (pretty _skolIdent)) 
             _ -> foldr ((<#>) . pretty . flip EscapedSkolems t . pure) empty esc
          , empty -- a line break
-         , bullet (string "Note: in type") <+> verbatim t
+         , note <+> string "in type" <+> verbatim t
          ]
 
   pretty (NotPromotable c x err) =
     vsep [ string "The constructor" <+> pretty c <+> string "can not be used as a type"
-         , string "Note: because its kind,"
+         , note <+> "because its kind,"
          , indent 2 (pretty x)
          , err
          ]
 
   pretty (SkolBinding (Skolem k v _ m) b) =
     vsep [ string "Could not match rigid type variable" <+> skol <+> string "with" <+> whatIs b
-         , bullet (string "Note: the variable") <+> skol <+> string "was rigidified because" <+> prettyMotive m
+         , note <+> "the variable" <+> skol <+> string "was rigidified because" <+> prettyMotive m
          , indent 8 (string "and is represented by the constant") <+> stypeSkol (pretty k)
          ] <#> case b of
              TySkol (Skolem k v _ m) ->
                vcat [ empty
-                    , vsep [ bullet (string "Note: the rigid type variable") <+> stypeVar (pretty v) <> comma <+> string "in turn" <> comma
+                    , vsep [ note <+> "the rigid type variable" <+> stypeVar (pretty v) <> comma <+> string "in turn" <> comma
                            , indent 8 (string "was rigidified because") <+> prettyMotive m
                            , indent 8 (string "and is represented by the constant") <+> stypeSkol (pretty k) ] ]
              _ -> empty
@@ -287,7 +287,7 @@ instance Pretty TypeError where
          , indent 4 $ string "This function expects a type as its first argument;"
          , indent 4 $ string "Have you forgotten an instantiation?"
          , empty
-         , bullet (string "Note:") <+> "You can use a hole like"
+         , note <+> "You can use a hole like"
              <+> pretty ((InstHole undefined) :: Expr Typed) <+> "to make the compiler infer this"
          ]
   pretty (WrongQuantifier (InstType t _) ty@TyArr{}) =

--- a/src/Core/Lower.hs
+++ b/src/Core/Lower.hs
@@ -259,8 +259,8 @@ lowerAnyway (RecordExt e xs _) = do
   where build (name, _) (atom, ty) = (name, ty, atom)
 
 lowerAnyway (Literal l _) = pure . Atom . Lit $ lowerLiteral l
+lowerAnyway (S.App f (InstType t _) _) = C.TyApp <$> lowerExprAtom f <*> pure (lowerType t)
 lowerAnyway (S.App f x _) = C.App <$> lowerExprAtom f <*> lowerExprAtom x
-lowerAnyway (S.InstApp f t _) = C.TyApp <$> lowerExprAtom f <*> pure (lowerType t)
 
 lowerAnyway e = error ("can't lower " ++ show e ++ " without type")
 

--- a/src/Core/Lower.hs
+++ b/src/Core/Lower.hs
@@ -260,6 +260,7 @@ lowerAnyway (RecordExt e xs _) = do
 
 lowerAnyway (Literal l _) = pure . Atom . Lit $ lowerLiteral l
 lowerAnyway (S.App f x _) = C.App <$> lowerExprAtom f <*> lowerExprAtom x
+lowerAnyway (S.InstApp f t _) = C.TyApp <$> lowerExprAtom f <*> pure (lowerType t)
 
 lowerAnyway e = error ("can't lower " ++ show e ++ " without type")
 
@@ -278,6 +279,7 @@ lowerType t@S.TyTuple{} = go t where
 lowerType (S.TyPi bind b)
   | S.Implicit v Nothing <- bind = ForallTy (Relevant (mkTyvar (S.unTvName v))) StarTy (lowerType b)
   | S.Implicit v (Just c) <- bind = ForallTy (Relevant (mkTyvar (S.unTvName v))) (lowerType c) (lowerType b)
+  | S.Explicit v c <- bind = ForallTy (Relevant (mkTyvar (S.unTvName v))) (lowerType c) (lowerType b)
   | S.Anon a <- bind = ForallTy Irrelevant (lowerType a) (lowerType b)
 lowerType (S.TyApp a b) = AppTy (lowerType a) (lowerType b)
 lowerType (S.TyRows rho vs) = RowsTy (lowerType rho) (map (fmap lowerType) vs)

--- a/src/Parser.y
+++ b/src/Parser.y
@@ -65,6 +65,7 @@ import Syntax
   '('      { Token TcOParen _ }
   ')'      { Token TcCParen _ }
   '@{'     { Token TcAtBrace _ }
+  '?'      { Token TcQuestion _ }
   '{'      { Token TcOBrace _ }
   '}'      { Token TcCBrace _ }
   '['      { Token TcOSquare _ }
@@ -129,7 +130,6 @@ Expr :: { Expr Parsed }
 ExprApp :: { Expr Parsed }
         : Expr0                                { $1 }
         | ExprApp Atom                         { withPos2 $1 $2 $ App $1 $2 }
-        | ExprApp '@{' Type '}'                { withPos2 $1 $4 $ InstApp $1 (getL $3) }
         | ExprApp ':' Type                     { withPos2 $1 $3 $ Ascription $1 (getL $3) }
 
 Expr0 :: { Expr Parsed }
@@ -157,6 +157,8 @@ Atom :: { Expr Parsed }
          { withPos2 $1 $5 $ tupleExpr ($2:$4) }
      | '{' Rows('=', Expr) '}'                { withPos2 $1 $3 $ Record $2 }
      | '{' Expr with Rows('=',Expr) '}'       { withPos2 $1 $5 $ RecordExt $2 $4 }
+     | '?'                                    { withPos1 $1 InstHole }
+     | '@{' Type '}'                          { withPos2 $1 $3 $ InstType (getL $2) }
 
      | Atom access                            { withPos2 $1 $2 $ Access $1 (getIdent $2) }
 

--- a/src/Parser/Lexer.x
+++ b/src/Parser/Lexer.x
@@ -95,6 +95,7 @@ tokens :-
   <0> ";"      { constTok TcSemicolon }
   <0> "("      { constTok TcOParen }
   <0> ")"      { constTok TcCParen }
+  <0> "@{"     { constTok TcAtBrace }
   <0> "{"      { constTok TcOBrace }
   <0> "}"      { constTok TcCBrace }
   H0> "["      { constTok TcOSquare }

--- a/src/Parser/Lexer.x
+++ b/src/Parser/Lexer.x
@@ -96,6 +96,7 @@ tokens :-
   <0> "("      { constTok TcOParen }
   <0> ")"      { constTok TcCParen }
   <0> "@{"     { constTok TcAtBrace }
+  <0> "?"      { constTok TcQuestion }
   <0> "{"      { constTok TcOBrace }
   <0> "}"      { constTok TcCBrace }
   H0> "["      { constTok TcOSquare }

--- a/src/Parser/Token.hs
+++ b/src/Parser/Token.hs
@@ -44,6 +44,7 @@ data TokenClass
   | TcOParen -- (
   | TcCParen -- )
   | TcAtBrace -- @{
+  | TcQuestion -- ?
   | TcOBrace -- {
   | TcCBrace -- }
   | TcOSquare -- [
@@ -114,6 +115,7 @@ instance Show TokenClass where
   show TcOParen = "("
   show TcCParen = ")"
   show TcAtBrace = "@{"
+  show TcQuestion = "?"
   show TcOBrace = "{"
   show TcCBrace = "}"
   show TcOSquare = "["

--- a/src/Parser/Token.hs
+++ b/src/Parser/Token.hs
@@ -43,6 +43,7 @@ data TokenClass
   | TcTopSep -- ;;
   | TcOParen -- (
   | TcCParen -- )
+  | TcAtBrace -- @{
   | TcOBrace -- {
   | TcCBrace -- }
   | TcOSquare -- [
@@ -112,6 +113,7 @@ instance Show TokenClass where
   show TcTopSep = ";;"
   show TcOParen = "("
   show TcCParen = ")"
+  show TcAtBrace = "@{"
   show TcOBrace = "{"
   show TcCBrace = "}"
   show TcOSquare = "["

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -100,7 +100,8 @@ data Expr p
   | TupleSection [Maybe (Expr p)] (Ann p)
 
   -- Visible instantiation
-  | InstApp (Expr p) (Type p) (Ann p)
+  | InstType (Type p) (Ann p)
+  | InstHole (Ann p)
 
   -- Module
   | OpenIn (Var p) (Expr p) (Ann p)

--- a/src/Syntax/Desugar.hs
+++ b/src/Syntax/Desugar.hs
@@ -58,7 +58,8 @@ desugarProgram = traverse statement where
     expr (Fun cap (Access ref k a) a)
 
   expr (Parens e _) = expr e
-  expr (InstApp e t a) = InstApp <$> expr e <*> pure t <*> pure a
+  expr e@InstHole{} = pure e
+  expr e@InstType{} = pure e
 
   expr (Tuple es a) = Tuple <$> traverse expr es <*> pure a
   expr (TupleSection es a) = do

--- a/src/Syntax/Desugar.hs
+++ b/src/Syntax/Desugar.hs
@@ -58,6 +58,7 @@ desugarProgram = traverse statement where
     expr (Fun cap (Access ref k a) a)
 
   expr (Parens e _) = expr e
+  expr (InstApp e t a) = InstApp <$> expr e <*> pure t <*> pure a
 
   expr (Tuple es a) = Tuple <$> traverse expr es <*> pure a
   expr (TupleSection es a) = do

--- a/src/Syntax/Let.hs
+++ b/src/Syntax/Let.hs
@@ -35,6 +35,7 @@ freeIn (Parens e _)         = freeIn e
 freeIn (LeftSection a b _)  = freeIn a <> freeIn b
 freeIn (RightSection a b _) = freeIn a <> freeIn b
 freeIn (BothSection b _)    = freeIn b
+freeIn (InstApp e _ _)      = freeIn e
 freeIn AccessSection{}      = mempty
 freeIn x = error (show x)
 

--- a/src/Syntax/Let.hs
+++ b/src/Syntax/Let.hs
@@ -35,8 +35,9 @@ freeIn (Parens e _)         = freeIn e
 freeIn (LeftSection a b _)  = freeIn a <> freeIn b
 freeIn (RightSection a b _) = freeIn a <> freeIn b
 freeIn (BothSection b _)    = freeIn b
-freeIn (InstApp e _ _)      = freeIn e
 freeIn AccessSection{}      = mempty
+freeIn InstHole{}           = mempty
+freeIn InstType{}           = mempty
 freeIn x = error (show x)
 
 bound :: Ord (Var p) => Pattern p -> Set.Set (Var p)

--- a/src/Syntax/Pretty.hs
+++ b/src/Syntax/Pretty.hs
@@ -45,7 +45,7 @@ instance (Pretty (Var p)) => Pretty (Expr p) where
                                        , keyword "else" <+> pretty e
                                        ])
   pretty (App f x _) = parenFun f <+> parenArg x
-  pretty (InstApp f t _) = parenFun f <+> soperator (string "@{") <+> pretty t <+> soperator (char '}')
+  pretty (InstType t _) = soperator (string "@{") <+> pretty t <+> soperator (char '}')
   pretty (Fun v e _) = keyword "fun" <+> pretty v <+> arrow <+> pretty e
   pretty (Begin e _) =
     vsep [ keyword "begin", indent 2 (vsep (punctuate semi (map pretty e))), keyword "end" ]
@@ -65,6 +65,7 @@ instance (Pretty (Var p)) => Pretty (Expr p) where
   pretty (BothSection op _) = parens $ pretty op
   pretty (AccessSection k _) = parens $ dot <> text k
   pretty (Parens e _) = parens $ pretty e
+  pretty (InstHole _) = keyword "?"
 
   pretty (Tuple es _) = parens (hsep (punctuate comma (map pretty es)))
   pretty (TupleSection es _) = parens (hsep (punctuate comma (map (maybe (string "") pretty) es)))
@@ -154,7 +155,7 @@ instance Pretty (Var p) => Pretty (TyBinder p) where
   pretty (Implicit v (Just k)) = braces (stypeVar (squote <> pretty v) <+> colon <+> pretty k) <> dot
   pretty (Implicit v Nothing)  = stypeVar (squote <> pretty v) <> dot
 
-  pretty (Explicit v k) = parens (stypeVar (squote <> pretty v) <+> colon <+> pretty k) <> arrow
+  pretty (Explicit v k) = parens (stypeVar (squote <> pretty v) <+> colon <+> pretty k) <+> arrow
 
 instance (Pretty (Var p)) => Pretty (Toplevel p) where
   pretty (LetStmt []) = error "absurd!"

--- a/src/Syntax/Pretty.hs
+++ b/src/Syntax/Pretty.hs
@@ -45,6 +45,7 @@ instance (Pretty (Var p)) => Pretty (Expr p) where
                                        , keyword "else" <+> pretty e
                                        ])
   pretty (App f x _) = parenFun f <+> parenArg x
+  pretty (InstApp f t _) = parenFun f <+> soperator (string "@{") <+> pretty t <+> soperator (char '}')
   pretty (Fun v e _) = keyword "fun" <+> pretty v <+> arrow <+> pretty e
   pretty (Begin e _) =
     vsep [ keyword "begin", indent 2 (vsep (punctuate semi (map pretty e))), keyword "end" ]
@@ -153,6 +154,8 @@ instance Pretty (Var p) => Pretty (TyBinder p) where
   pretty (Implicit v (Just k)) = braces (stypeVar (squote <> pretty v) <+> colon <+> pretty k) <> dot
   pretty (Implicit v Nothing)  = stypeVar (squote <> pretty v) <> dot
 
+  pretty (Explicit v k) = parens (stypeVar (squote <> pretty v) <+> colon <+> pretty k) <> arrow
+
 instance (Pretty (Var p)) => Pretty (Toplevel p) where
   pretty (LetStmt []) = error "absurd!"
   pretty (LetStmt ((n, v, _):xs)) =
@@ -227,6 +230,7 @@ applyCons x@TyPromotedCon{} = x
 applyCons (TyPi a b) = TyPi (go a) (applyCons b) where
   go (Anon t) = Anon (applyCons t)
   go (Implicit t k) = Implicit t (fmap applyCons k)
+  go (Explicit t k) = Explicit t (applyCons k)
 applyCons (TyApp a b) = TyApp (applyCons a) (applyCons b)
 applyCons (TyRows r rs) = TyRows (applyCons r) (map (second applyCons) rs)
 applyCons (TyExactRows rs) = TyExactRows (map (second applyCons) rs)

--- a/src/Syntax/Raise.hs
+++ b/src/Syntax/Raise.hs
@@ -21,4 +21,5 @@ raiseT v (TyWithConstraints eq a) = TyWithConstraints (map (\(a, b) -> (raiseT v
 raiseT v (TyPi binder t) = TyPi (go binder) (raiseT v t) where
   go (Anon t) = Anon (raiseT v t)
   go (Implicit var k) = Implicit (v var) (fmap (raiseT v) k)
+  go (Explicit var k) = Explicit (v var) (raiseT v k)
 raiseT _ TyType = TyType

--- a/src/Syntax/Resolve.hs
+++ b/src/Syntax/Resolve.hs
@@ -258,7 +258,7 @@ reExpr r@(Ascription e t a) = Ascription
                           <$> reExpr e
                           <*> reType r t
                           <*> pure a
-reExpr r@(InstApp e t a) = InstApp <$> reExpr e <*> reType r t <*> pure a
+reExpr r@(InstType t a) = InstType <$> reType r t <*> pure a
 reExpr (Record fs a) = Record <$> traverse (traverse reExpr) fs <*> pure a
 reExpr (RecordExt e fs a) = RecordExt
                         <$> reExpr e
@@ -279,6 +279,7 @@ reExpr r@(OpenIn m e a) =
   `catchError` (throwError . wrapError r)
 
 reExpr ExprWrapper{} = error "resolve cast"
+reExpr (InstHole a) = pure $ InstHole a
 
 reType :: (MonadResolve m, Reasonable a p)
        => a p -> Type Parsed -> m (Type Resolved)

--- a/src/Syntax/Resolve.hs
+++ b/src/Syntax/Resolve.hs
@@ -258,6 +258,7 @@ reExpr r@(Ascription e t a) = Ascription
                           <$> reExpr e
                           <*> reType r t
                           <*> pure a
+reExpr r@(InstApp e t a) = InstApp <$> reExpr e <*> reType r t <*> pure a
 reExpr (Record fs a) = Record <$> traverse (traverse reExpr) fs <*> pure a
 reExpr (RecordExt e fs a) = RecordExt
                         <$> reExpr e
@@ -291,6 +292,11 @@ reType r (TyPi (Implicit v k) ty) = do
   ty' <- extendTyvar (v, v') $ reType r ty
   k <- traverse (reType r) k
   pure (TyPi (Implicit v' k) ty')
+reType r (TyPi (Explicit v k) ty) = do
+  v' <- tagVar v
+  ty' <- extendTyvar (v, v') $ reType r ty
+  k <- reType r k
+  pure (TyPi (Explicit v' k) ty')
 reType r (TyPi (Anon f) x) = TyPi . Anon <$> reType r f <*> reType r x
 reType r (TyApp f x) = TyApp <$> reType r f <*> reType r x
 reType r (TyRows t f) = TyRows <$> reType r t

--- a/src/Syntax/Subst.hs
+++ b/src/Syntax/Subst.hs
@@ -90,13 +90,16 @@ instance (Ord (Var p), Substitutable p a) => Substitutable p (Seq.Seq a) where
 instance Ord (Var p) => Substitutable p (TyBinder p) where
   ftv (Anon t) = ftv t
   ftv (Implicit _ k) = maybe mempty ftv k
+  ftv (Explicit _ k) = ftv k
 
   apply s (Anon t) = Anon (apply s t)
   apply s (Implicit v k) = Implicit v (fmap (apply s) k)
+  apply s (Explicit v k) = Explicit v (apply s k)
 
 bound :: Ord (Var p) => TyBinder p -> Set.Set (Var p)
 bound Anon{} = Set.empty
 bound (Implicit v _) = Set.singleton v
+bound (Explicit v _) = Set.singleton v
 
 compose :: Ord (Var p) => Subst p -> Subst p -> Subst p
 s1 `compose` s2 = fmap (apply s1) s2 <> fmap (apply s2) s1

--- a/src/Syntax/Transform.hs
+++ b/src/Syntax/Transform.hs
@@ -86,7 +86,8 @@ transformExpr fe = goE where
 
   transE (OpenIn n e a) = OpenIn n (goE e) a
 
-  transE (InstApp e t a) = InstApp (goE e) t a
+  transE (InstType t a) = InstType t a
+  transE (InstHole a) = InstHole a
 
   transE (ExprWrapper w e a) = ExprWrapper w (goE e) a
 
@@ -125,7 +126,8 @@ transformExprTyped fe fc ft = goE where
   transE (TupleSection es a) = TupleSection (map (goE<$>) es) (goA a)
 
   transE (OpenIn n e a) = OpenIn n (goE e) (goA a)
-  transE (InstApp e t a) = InstApp (goE e) (goT t) (goA a)
+  transE (InstType t a) = InstType (goT t) (goA a)
+  transE (InstHole a) = InstHole (goA a)
 
   transE (ExprWrapper w e a) = ExprWrapper (goW w) (goE e) (goA a)
 
@@ -189,6 +191,7 @@ correct ty (Tuple es a) = Tuple es (fst a, ty)
 correct ty (TupleSection es a) = TupleSection es (fst a, ty)
 
 correct ty (OpenIn n e a) = OpenIn n e (fst a, ty)
-correct ty (InstApp f t a) = InstApp f t (fst a, ty)
+correct ty (InstType t a) = InstType t (fst a, ty)
+correct ty (InstHole a) = InstHole (fst a, ty)
 
 correct ty (ExprWrapper w e a) = ExprWrapper w e (fst a, ty)

--- a/src/Syntax/Transform.hs
+++ b/src/Syntax/Transform.hs
@@ -29,6 +29,7 @@ transformType ft = goT where
 
   transB (Anon t) = Anon (goT t)
   transB (Implicit x k) = Implicit x (fmap goT k)
+  transB (Explicit x k) = Explicit x (goT k)
 
   goT = transT . ft
 
@@ -85,6 +86,8 @@ transformExpr fe = goE where
 
   transE (OpenIn n e a) = OpenIn n (goE e) a
 
+  transE (InstApp e t a) = InstApp (goE e) t a
+
   transE (ExprWrapper w e a) = ExprWrapper w (goE e) a
 
   goE = transE . fe
@@ -122,6 +125,7 @@ transformExprTyped fe fc ft = goE where
   transE (TupleSection es a) = TupleSection (map (goE<$>) es) (goA a)
 
   transE (OpenIn n e a) = OpenIn n (goE e) (goA a)
+  transE (InstApp e t a) = InstApp (goE e) (goT t) (goA a)
 
   transE (ExprWrapper w e a) = ExprWrapper (goW w) (goE e) (goA a)
 
@@ -185,5 +189,6 @@ correct ty (Tuple es a) = Tuple es (fst a, ty)
 correct ty (TupleSection es a) = TupleSection es (fst a, ty)
 
 correct ty (OpenIn n e a) = OpenIn n e (fst a, ty)
+correct ty (InstApp f t a) = InstApp f t (fst a, ty)
 
 correct ty (ExprWrapper w e a) = ExprWrapper w e (fst a, ty)

--- a/src/Text/Pretty/Semantic.hs
+++ b/src/Text/Pretty/Semantic.hs
@@ -13,7 +13,7 @@ module Text.Pretty.Semantic
 
   , skeyword, sliteral, sstring, scomment, stypeCon, stypeVar, stypeSkol, soperator
 
-  , arrow, equals, colon, prod, pipe
+  , arrow, equals, colon, prod, pipe, note
   , keyword, highlight
   , verbatim
   ) where
@@ -123,3 +123,6 @@ highlight = stypeSkol . string
 
 verbatim :: Pretty a => a -> Doc
 verbatim = enclose (char '`') (char '`') . pretty
+
+note :: P.Doc a
+note = bullet (string "Note:")

--- a/src/Types/Wellformed.hs
+++ b/src/Types/Wellformed.hs
@@ -21,6 +21,7 @@ wellformed tp = case tp of
   TyPi a b -> do
     case a of
       Implicit _ k -> traverse_ wellformed k
+      Explicit _ k -> wellformed k
       Anon a -> wellformed a 
     wellformed b
   TyApp a b -> wellformed a *> wellformed b
@@ -74,6 +75,7 @@ skols (TySkol x) = Set.singleton x
 skols (TyApp a b) = skols a <> skols b
 skols (TyPi b t)
   | Implicit _ k <- b = skols t <> foldMap skols k
+  | Explicit _ k <- b = skols t <> skols k
   | Anon a <- b = skols a <> skols t
 skols (TyRows r rs) = skols r <> foldMap (skols . snd) rs
 skols (TyExactRows rs) = foldMap (skols . snd) rs

--- a/tests/gadt/fail_term.out
+++ b/tests/gadt/fail_term.out
@@ -9,7 +9,7 @@ fail_term.ml[16:3 ..16:30]: error
   against the type {'a : type}. {'b : type}. term unit ('a -> 'b -> 'b)
           and is represented by the constant pg
 
-  Arising from use of the expression
+  Arising in the expression
    │ 
 16 │   Lam (Lam (Var (There Here)))
    │ 

--- a/tests/gadt/gadt01.out
+++ b/tests/gadt/gadt01.out
@@ -2,7 +2,7 @@ gadt01.ml[3:16 ..3:20]: error
   Could not match type type with 'e -> type
   Have you applied a type constructor to the wrong number of arguments?
 
-  Arising from use of the declaration
+  Arising in the declaration
   │ 
 3 │ type gadt 'a = R : gadt
   │ 

--- a/tests/gadt/gadt02.out
+++ b/tests/gadt/gadt02.out
@@ -7,7 +7,7 @@ gadt02.ml[7:5 ..7:23]: error
   • Suggestion: did you mean t1 bool
                 instead of t2 bool?
 
-  Arising from use of the constructor
+  Arising in the constructor
   │ 
 7 │   | K2 : t2 int -> t2 bool
   │ 

--- a/tests/gadt/gadt03-fail.out
+++ b/tests/gadt/gadt03-fail.out
@@ -1,7 +1,7 @@
 gadt03-fail.ml[7:12 ..7:12]: error
   Could not match type int with bool
 
-  Arising from use of the expression
+  Arising in the expression
   │ 
 7 │ let show = function
   │ 

--- a/tests/gadt/gadt04-pass.out
+++ b/tests/gadt/gadt04-pass.out
@@ -3,7 +3,7 @@ gadt04-pass.ml[2:5 ..2:27]: error
   • Note: Generalised constructors can not be curried
   • Suggestion: Perhaps use a tuple: `(int * int) -> t`
 
-  Arising from use of the constructor
+  Arising in the constructor
   │ 
 2 │   | MkT : int -> (int -> t)
   │ 

--- a/tests/gadt/gadt07-escape-fail.out
+++ b/tests/gadt/gadt07-escape-fail.out
@@ -5,7 +5,7 @@ gadt07-escape-fail.ml[10:3 ..10:14]: error
           and is represented by the constant cp
 
 
-  Arising from use of the expression
+  Arising in the expression
    │ 
 10 │   match hval with
    │ 

--- a/tests/rankn/impredicative01-fail.out
+++ b/tests/rankn/impredicative01-fail.out
@@ -4,7 +4,7 @@ impredicative01-fail.ml[3:5 ..3:34]: error
   • Note: instantiating a type variable (the argument to `foo`)
     with a polymorphic type constitutes impredicative polymorphism
 
-  Arising from use of the declaration
+  Arising in the declaration
   │ 
 3 │ let main : foo (forall 'a. 'a) = main
   │ 

--- a/tests/types/fail_skolem_escape.out
+++ b/tests/types/fail_skolem_escape.out
@@ -7,7 +7,7 @@ fail_skolem_escape.ml[2:19 ..2:38]: error
   • Note: in type `aw`
   • Note: in the inferred type for escape_fail
 
-  Arising from use of the expression
+  Arising in the expression
   │ 
 2 │ let escape_fail = escapes (fun x -> x)
   │ 

--- a/tests/types/fail_skolem_poly.out
+++ b/tests/types/fail_skolem_poly.out
@@ -5,7 +5,7 @@ fail_skolem_poly.ml[2:32 ..2:32]: error
           and is represented by the constant aq
 
 
-  Arising from use of the expression
+  Arising in the expression
   │ 
 2 │ let poly_fail = poly (fun x -> x + 1)
   │ 
@@ -16,7 +16,7 @@ fail_skolem_poly.ml[2:32 ..2:36]: error
           and is represented by the constant aq
 
 
-  Arising from use of the expression
+  Arising in the expression
   │ 
 2 │ let poly_fail = poly (fun x -> x + 1)
   │ 

--- a/tests/types/fail_skolem_pure.out
+++ b/tests/types/fail_skolem_pure.out
@@ -5,7 +5,7 @@ fail_skolem_pure.ml[2:32 ..2:32]: error
           and is represented by the constant bq
 
 
-  Arising from use of the expression
+  Arising in the expression
   │ 
 2 │ let pure_fail = pure (fun x -> x)
   │ 

--- a/tests/visinst/visible01-fail.ml
+++ b/tests/visinst/visible01-fail.ml
@@ -1,0 +1,4 @@
+let foo : forall ('a : type) -> 'a -> 'a = fun x -> x
+
+let bar = foo @{string} 1
+and baz = foo @{unit} 1

--- a/tests/visinst/visible01-fail.out
+++ b/tests/visinst/visible01-fail.out
@@ -1,0 +1,7 @@
+visible01-fail.ml[4:23 ..4:23]: error
+  Could not match type unit with int
+
+  Arising in the expression
+  │ 
+4 │ and baz = foo @{unit} 1
+  │ 

--- a/tests/visinst/visible01-pass.ml
+++ b/tests/visinst/visible01-pass.ml
@@ -1,0 +1,4 @@
+let foo : forall ('a : type) -> 'a -> 'a = fun x -> x
+
+let bar = foo @{int} 1
+and baz = foo ? 1

--- a/tests/visinst/visible01-pass.out
+++ b/tests/visinst/visible01-pass.out
@@ -1,0 +1,3 @@
+foo : ('a : type) -> 'a -> 'a
+bar : int
+baz : int

--- a/tests/visinst/visible02-fail.ml
+++ b/tests/visinst/visible02-fail.ml
@@ -1,0 +1,2 @@
+let main = ?
+and main' = @{int}

--- a/tests/visinst/visible02-fail.out
+++ b/tests/visinst/visible02-fail.out
@@ -1,0 +1,8 @@
+visible02-fail.ml[1:5 ..2:18]: error
+  Can not use the type @{ int } outside of a type application
+
+  Arising in the declaration
+  │ 
+1 │ let main = ?    
+2 │ and main' = @{int}
+  │ 

--- a/tests/visinst/visible03-fail.ml
+++ b/tests/visinst/visible03-fail.ml
@@ -1,0 +1,3 @@
+let foo : forall ('a : type) -> 'a -> int = fun _ -> 0
+
+let main = foo 1

--- a/tests/visinst/visible03-fail.out
+++ b/tests/visinst/visible03-fail.out
@@ -1,0 +1,11 @@
+visible03-fail.ml[3:12 ..3:16]: error
+  Expression given as argument to function of type ('a : type) -> 'a -> int
+      This function expects a type as its first argument;
+      Have you forgotten an instantiation?
+
+  • Note: You can use a hole like ? to make the compiler infer this
+
+  Arising in the expression
+  │ 
+3 │ let main = foo 1
+  │ 

--- a/tests/visinst/visible04-fail.ml
+++ b/tests/visinst/visible04-fail.ml
@@ -1,0 +1,4 @@
+let foo : forall ('a : type) -> 'a -> forall ('b : type) -> 'b -> 'a =
+  fun x _ -> x ;;
+
+let main = foo @{unit} 1 @{unit} ()

--- a/tests/visinst/visible04-fail.out
+++ b/tests/visinst/visible04-fail.out
@@ -1,0 +1,7 @@
+visible04-fail.ml[4:24 ..4:24]: error
+  Could not match type unit with int
+
+  Arising in the expression
+  │ 
+4 │ let main = foo @{unit} 1 @{unit} ()
+  │ 

--- a/tests/visinst/visible04-pass.ml
+++ b/tests/visinst/visible04-pass.ml
@@ -1,0 +1,4 @@
+let foo : forall ('a : type) -> 'a -> forall ('b : type) -> 'b -> 'a =
+  fun x _ -> x ;;
+
+let main = foo @{int} 1 @{unit} ()

--- a/tests/visinst/visible04-pass.out
+++ b/tests/visinst/visible04-pass.out
@@ -1,0 +1,2 @@
+foo : ('a : type) -> 'a -> ('b : type) -> 'b -> 'a
+main : int


### PR DESCRIPTION
This PR adds a new form of type, `forall ('a : k) -> t`, which is to be used both visibly and relevantly. This is _not_ dependent types, yet.

The "regular" behaviour of `forall 'a. t` can be regained when you have a function of type `forall ('a : k) -> t` by using `f ?`.

We still don't have visible type lambdas, because that would frankly be quite a mess.