### PR TITLE
Componentwise Tuple Subsumption

### DIFF
--- a/src/Core/Builtin.hs
+++ b/src/Core/Builtin.hs
@@ -72,6 +72,10 @@ tyvarA, tyvarB :: CoVar
 tyvarA = CoVar (-30) "a" TypeVar
 tyvarB = CoVar (-31) "b" TypeVar
 
+builtinFst, builtinSnd :: CoVar
+builtinFst = CoVar (-32) "fst" ValueVar
+builtinSnd = CoVar (-33) "snd" ValueVar
+
 builtinVarList :: (IsVar a, IsVar b) => [(a, Type b)]
 builtinVarList = vars where
   op x t = (fromVar x, t)

--- a/src/Core/Lower.hs
+++ b/src/Core/Lower.hs
@@ -1,5 +1,5 @@
+{-# LANGUAGE LambdaCase, TupleSections, ExplicitNamespaces, PatternSynonyms, RankNTypes, ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleContexts, ConstraintKinds, OverloadedStrings #-}
-{-# LANGUAGE LambdaCase, TupleSections, ExplicitNamespaces, PatternSynonyms #-}
 module Core.Lower
   ( runLowerT
   , lowerExprTerm
@@ -324,15 +324,15 @@ lowerPat (PTuple xs _) =
    in go xs
 lowerPat (PLiteral l _) = pure (PatLit (lowerLiteral l))
 
-lowerProg :: MonadLower m => [Toplevel Typed] -> m [Stmt]
-lowerProg [] = pure []
-lowerProg (ForeignVal (TvName t) ex tp _:prg) =
-  (Foreign (mkVal t) (lowerType tp) ex:) <$> lowerProg prg
-lowerProg (LetStmt vs:prg) = do
+lowerProg, lowerProg' :: forall m. MonadLower m => [Toplevel Typed] -> m [Stmt]
+lowerProg' [] = pure []
+lowerProg' (ForeignVal (TvName t) ex tp _:prg) =
+  (Foreign (mkVal t) (lowerType tp) ex:) <$> lowerProg' prg
+lowerProg' (LetStmt vs:prg) = do
   let env' = Map.fromList (map (\(TvName v, _, (_, ant)) -> (v, lowerType ant)) vs)
   (:) <$> local (\s -> s { vars = env' }) (StmtLet <$> for vs (\(TvName v, ex, (_, ant)) -> (mkVal v,lowerType ant,) <$> lowerPolyBind (lowerType ant) ex))
-      <*> lowerProg prg
-lowerProg (TypeDecl (TvName var) _ cons:prg) = do
+      <*> lowerProg' prg
+lowerProg' (TypeDecl (TvName var) _ cons:prg) = do
   let cons' = map (\case
                        UnitCon (TvName p) (_, t) -> (p, mkCon p, lowerType t)
                        ArgCon (TvName p) _ (_, t) -> (p, mkCon p, lowerType t)
@@ -341,10 +341,37 @@ lowerProg (TypeDecl (TvName var) _ cons:prg) = do
       ccons = map (\(_, a, b) -> (a, b)) cons'
       scons = map (\(a, _, b) -> (a, b)) cons'
 
-  (C.Type (mkType var) ccons:) <$> local (\s -> s { ctors = Map.union (Map.fromList scons) (ctors s) }) (lowerProg prg)
-lowerProg (Open _ _:prg) = lowerProg prg
-lowerProg (Module _ b:prg) = lowerProg (b ++prg)
+  (C.Type (mkType var) ccons:) <$> local (\s -> s { ctors = Map.union (Map.fromList scons) (ctors s) }) (lowerProg' prg)
+lowerProg' (Open _ _:prg) = lowerProg' prg
+lowerProg' (Module _ b:prg) = lowerProg' (b ++ prg)
 
+lowerProg p = (++) <$> mkBuiltins <*> lowerProg' p where
+  mkBuiltins = do
+    vvs <- replicateM 3 (fresh ValueVar)
+    let vs = vvs ++ [ C.tyvarA, C.tyvarB ]
+
+    (at, fst) <- mkBuiltinTuple vs fst
+    (bt, snd) <- mkBuiltinTuple vs snd
+    pure [ StmtLet [(C.builtinFst, at, fst)], StmtLet [(C.builtinSnd, bt, snd)] ]
+
+  mkBuiltinTuple :: [CoVar] -> (forall a. (a, a) -> a) -> m (C.Type CoVar, C.Term CoVar)
+  mkBuiltinTuple [arg, x, y, a, b] f = do
+    let tuple = ExactRowsTy [("1", VarTy a), ("2", VarTy b)]
+        ty = ForallTy (Relevant a) StarTy $
+              ForallTy (Relevant b) StarTy $
+                ForallTy Irrelevant tuple $
+                  f (VarTy a, VarTy b)
+        def = Atom $ Lam (TypeArgument a StarTy) $
+               Atom $ Lam (TypeArgument b StarTy) $
+                 Atom $ Lam (TermArgument arg tuple) $
+                   C.Match (Ref arg tuple)
+                    [ C.Arm { _armPtrn = PatExtend (PatLit RecNil) [("1", C.Capture x (VarTy a)), ("2", C.Capture y (VarTy b))]
+                            , _armTy   = tuple
+                            , _armBody = Atom (f (Ref x (VarTy a), Ref y (VarTy b)))
+                            , _armVars = [(x, VarTy a), (y, VarTy b)]
+                            , _armTyvars = [] } ]
+    pure (ty, def)
+  mkBuiltinTuple _ _ = undefined
 
 lowerPolyBind :: MonadLower m => Type -> Expr Typed -> m Term
 lowerPolyBind ty ex = doIt (needed ex ty) (go ty ex) (lowerExprTerm ex) where

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -123,7 +123,7 @@ data Wrapper p
   | WrapFn (WrapCont p)
   | IdWrap
 
-newtype WrapCont p = MkWrapCont { runWrapper :: Expr p -> Expr p }
+data WrapCont p = MkWrapCont { runWrapper :: Expr p -> Expr p, desc :: String }
 
 deriving instance Typeable p => Typeable (WrapCont p)
 instance Typeable p => Data (WrapCont p) where
@@ -133,7 +133,9 @@ instance Typeable p => Data (WrapCont p) where
 
 instance Eq (WrapCont p) where _ == _ = False
 instance Ord (WrapCont p) where _ `compare` _ = GT
-instance Show (WrapCont p) where show _ = "<wrapper continuation>"
+
+instance Show (WrapCont p) where
+  show = desc
 
 infixr 5 :>
 

--- a/src/Syntax/Transform.hs
+++ b/src/Syntax/Transform.hs
@@ -160,7 +160,7 @@ transformPatternTyped fp ft = goP where
   transP (PLiteral l a) = PLiteral l (goA a)
 
   goA (s, ty) = (s, goT ty)
-  goT = transformType ft
+  goT = ft
   goP = transP . fp
 
 correct :: Type Typed -> Expr Typed -> Expr Typed

--- a/src/Types/Infer.hs
+++ b/src/Types/Infer.hs
@@ -403,4 +403,3 @@ solveEx _ ss cs = transformExprTyped go id goType where
 
 consFst :: Functor m => a -> m ([a], b) -> m ([a], b)
 consFst = fmap . first . (:)
-

--- a/src/Types/Infer.hs
+++ b/src/Types/Infer.hs
@@ -397,7 +397,7 @@ solveEx _ ss cs = transformExprTyped go id goType where
   goWrap (WrapVar v) = goWrap $ Map.findWithDefault err v cs where
     err = error $ "Unsolved wrapper variable " ++ show v ++ ". This is a bug"
   goWrap IdWrap = IdWrap
-  goWrap (WrapFn f) = WrapFn f
+  goWrap (WrapFn f) = WrapFn . flip MkWrapCont (desc f) $ solveEx undefined ss cs . runWrapper f
 
   goType = apply ss
 

--- a/src/Types/Infer/Builtin.hs
+++ b/src/Types/Infer/Builtin.hs
@@ -164,3 +164,19 @@ gadtConResult :: Type p -> Type p
 gadtConResult (TyForall _ _ t) = gadtConResult t
 gadtConResult (TyArr _ t) = t
 gadtConResult t = t
+
+firstName, secondName :: Var Typed
+firstName = TvName (TgName "$fst" (-32))
+secondName = TvName (TgName "$snd" (-33))
+
+firstTy, secondTy :: Type Typed
+firstTy = TyForall (TvName (TgName "a" (-30))) (Just TyType) (firstTy' (TyVar (TvName (TgName "a" (-30)))))
+secondTy = TyForall (TvName (TgName "a" (-30))) (Just TyType) (secondTy' (TyVar (TvName (TgName "a" (-30)))))
+
+firstTy', secondTy' :: Type Typed -> Type Typed
+firstTy' x = TyForall (TvName (TgName "b" (-31))) (Just TyType) (firstTy'' x (TyVar (TvName (TgName "b" (-31)))))
+secondTy' x = TyForall (TvName (TgName "b" (-31))) (Just TyType) (secondTy'' x (TyVar (TvName (TgName "b" (-31)))))
+
+firstTy'', secondTy'' :: Type Typed -> Type Typed -> Type Typed
+firstTy'' x y = TyArr (TyTuple x y) x
+secondTy'' x y = TyArr (TyTuple x y) y

--- a/src/Types/Unify.hs
+++ b/src/Types/Unify.hs
@@ -265,6 +265,13 @@ subsumes k t1@TyPi{} t2 | isSkolemisable t1 = do
   (cont, _, t1') <- instantiate t1
   let wrap = maybe IdWrap (WrapFn . MkWrapCont) cont
   (Syntax.:>) wrap <$> subsumes k t1' t2
+subsumes k (TyTuple a b) (TyTuple a' b') = do
+  wa <- subsumes k a' a
+  wb <- subsumes k b' b
+  let cont (Tuple (e:es) (at, _)) = Tuple [ExprWrapper wa e (at, a'), ExprWrapper wb (Tuple es (at, b)) (at, b')] (at, TyTuple a' b')
+      cont _ = error "TODO"
+      cont :: Expr Typed -> Expr Typed
+  pure (WrapFn (MkWrapCont cont))
 subsumes k a b = Cast <$> k a b
 
 skolemise :: MonadGen Int m => SkolemMotive Typed -> Type Typed -> m (Wrapper Typed, Type Typed)

--- a/src/Types/Unify.hs
+++ b/src/Types/Unify.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE MultiWayIf, GADTs, FlexibleContexts, ScopedTypeVariables, TemplateHaskell #-}
-{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TupleSections, OverloadedStrings #-}
 module Types.Unify (solve, overlap, bind, skolemise, freshSkol) where
 
 import Control.Monad.Except
@@ -18,6 +18,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import Data.Sequence (Seq ((:<|), Empty))
+import Data.Spanned
 import Data.Foldable
 import Data.Function
 import Data.List
@@ -263,15 +264,30 @@ subsumes k t1 t2@TyPi{} | isSkolemisable t2 = do
   (Syntax.:>) c <$> subsumes k t1 t2'
 subsumes k t1@TyPi{} t2 | isSkolemisable t1 = do
   (cont, _, t1') <- instantiate t1
-  let wrap = maybe IdWrap (WrapFn . MkWrapCont) cont
-  (Syntax.:>) wrap <$> subsumes k t1' t2
-subsumes k (TyTuple a b) (TyTuple a' b') = do
-  wa <- subsumes k a' a
-  wb <- subsumes k b' b
-  let cont (Tuple (e:es) (at, _)) = Tuple [ExprWrapper wa e (at, a'), ExprWrapper wb (Tuple es (at, b)) (at, b')] (at, TyTuple a' b')
-      cont _ = error "TODO"
-      cont :: Expr Typed -> Expr Typed
-  pure (WrapFn (MkWrapCont cont))
+  let wrap = maybe IdWrap (WrapFn . flip MkWrapCont "forall <= sigma; instantiation") cont
+
+  flip (Syntax.:>) wrap <$> subsumes k t1' t2
+
+subsumes k nt@(TyTuple a' b') ot@(TyTuple a b) = do
+  wa <- subsumes k a a'
+  wb <- subsumes k b b'
+  var <- fresh
+  let ref an = VarRef (TvName var) (an, ot)
+      firstElem an ex = App (ExprWrapper (TypeApp b) (ExprWrapper (TypeApp a)
+                                                        (VarRef firstName (an, firstTy))
+                                                        (an, firstTy' a))
+                                (an, firstTy'' a b)) ex (an, a)
+      secondElem an ex = App (ExprWrapper (TypeApp b) (ExprWrapper (TypeApp a)
+                                                        (VarRef secondName (an, secondTy))
+                                                        (an, secondTy' a))
+                                (an, secondTy'' a b)) ex (an, b)
+      cont ex
+        | an <- annotation ex =
+          Let [(TvName var, ex, (an, ot))]
+           (Tuple [ExprWrapper wa (firstElem an (ref an)) (an, a'), ExprWrapper wb (secondElem an (ref an)) (an, b')] (an, nt))
+           (an, nt)
+  pure (WrapFn (MkWrapCont cont "tuple re-packing"))
+
 subsumes k a b = Cast <$> k a b
 
 skolemise :: MonadGen Int m => SkolemMotive Typed -> Type Typed -> m (Wrapper Typed, Type Typed)
@@ -310,3 +326,19 @@ capture m = do
 
 catchy :: MonadError e m => m a -> m (Either e a)
 catchy x = (Right <$> x) `catchError` (pure . Left)
+
+firstName, secondName :: Var Typed
+firstName = TvName (TgName "$fst" (-32))
+secondName = TvName (TgName "$snd" (-33))
+
+firstTy, secondTy :: Type Typed
+firstTy = TyForall (TvName (TgName "a" (-30))) (Just TyType) (firstTy' (TyVar (TvName (TgName "a" (-30)))))
+secondTy = TyForall (TvName (TgName "a" (-30))) (Just TyType) (secondTy' (TyVar (TvName (TgName "a" (-30)))))
+
+firstTy', secondTy' :: Type Typed -> Type Typed
+firstTy' x = TyForall (TvName (TgName "b" (-31))) (Just TyType) (firstTy'' x (TyVar (TvName (TgName "b" (-31)))))
+secondTy' x = TyForall (TvName (TgName "b" (-31))) (Just TyType) (secondTy'' x (TyVar (TvName (TgName "b" (-31)))))
+
+firstTy'', secondTy'' :: Type Typed -> Type Typed -> Type Typed
+firstTy'' x y = TyArr (TyTuple x y) x
+secondTy'' x y = TyArr (TyTuple x y) y

--- a/src/Types/Unify.hs
+++ b/src/Types/Unify.hs
@@ -8,6 +8,7 @@ import Control.Applicative
 import Control.Monad.Infer
 import Control.Lens hiding (Empty)
 
+import Types.Infer.Builtin hiding (subsumes, unify)
 import Types.Infer.Errors
 import Types.Wellformed
 
@@ -326,19 +327,3 @@ capture m = do
 
 catchy :: MonadError e m => m a -> m (Either e a)
 catchy x = (Right <$> x) `catchError` (pure . Left)
-
-firstName, secondName :: Var Typed
-firstName = TvName (TgName "$fst" (-32))
-secondName = TvName (TgName "$snd" (-33))
-
-firstTy, secondTy :: Type Typed
-firstTy = TyForall (TvName (TgName "a" (-30))) (Just TyType) (firstTy' (TyVar (TvName (TgName "a" (-30)))))
-secondTy = TyForall (TvName (TgName "a" (-30))) (Just TyType) (secondTy' (TyVar (TvName (TgName "a" (-30)))))
-
-firstTy', secondTy' :: Type Typed -> Type Typed
-firstTy' x = TyForall (TvName (TgName "b" (-31))) (Just TyType) (firstTy'' x (TyVar (TvName (TgName "b" (-31)))))
-secondTy' x = TyForall (TvName (TgName "b" (-31))) (Just TyType) (secondTy'' x (TyVar (TvName (TgName "b" (-31)))))
-
-firstTy'', secondTy'' :: Type Typed -> Type Typed -> Type Typed
-firstTy'' x y = TyArr (TyTuple x y) x
-secondTy'' x y = TyArr (TyTuple x y) y

--- a/tests/lua/match_multi.lua
+++ b/tests/lua/match_multi.lua
@@ -1,7 +1,7 @@
 do
   local function main (f)
-    local al = f(nil)
-    return al.a + al.b
+    local ao = f(nil)
+    return ao.a + ao.b
   end
   main()
 end

--- a/tests/rankn/tuple01-pass.ml
+++ b/tests/rankn/tuple01-pass.ml
@@ -1,0 +1,7 @@
+let foo : (forall 'a. 'a -> 'a) * (forall 'a. 'a -> int) = (fun x -> x, fun x -> 1)
+
+let fst (x, y) = x
+let snd (x, y) = y
+
+let main =
+  fst foo 1 + snd foo ()

--- a/tests/rankn/tuple01-pass.out
+++ b/tests/rankn/tuple01-pass.out
@@ -1,0 +1,4 @@
+foo : {'a : type}. 'a -> 'a * {'a : type}. 'a -> int
+fst : {'ai : type}. {'ap : type}. ('ai * 'ap) -> 'ai
+snd : {'az : type}. {'bf : type}. ('bf * 'az) -> 'az
+main : int

--- a/tests/rankn/tuple02-fail.ml
+++ b/tests/rankn/tuple02-fail.ml
@@ -1,0 +1,1 @@
+let foo : (forall 'a. 'a -> 'a) * int = (fun 0 -> (), 1)

--- a/tests/rankn/tuple02-fail.out
+++ b/tests/rankn/tuple02-fail.out
@@ -1,0 +1,9 @@
+tuple02-fail.ml[1:41 ..1:56]: error
+  Could not match rigid type variable a with the type int
+  • Note: the variable a was rigidified because of a subsumption constraint relating int -> unit with {'a : type}. 'a -> 'a
+
+
+  Arising in the expression
+  │ 
+1 │ let foo : (forall 'a. 'a -> 'a) * int = (fun 0 -> (), 1)
+  │ 


### PR DESCRIPTION
This adds Amulet's first two wired-in names with unfoldings, `fst#`
(-32) and `snd#` (-33). The GHC-inspired magic hash is there to indicate
magic; These bindings are not user accessible and are basically only
added by the type checker.

`fst#` and `snd#` are used to re-build tuples at use sites that impose
subsumption constraints. Consider we need to solve

    "('a * 'b) <= ('c * 'd)"

We start by decomposing these into

    'c <= 'a (call this wrapper α)
    'd <= 'b (call this wrapper β)

Then, we re-build the tuple (call it x, with ξ fresh) like so:

    let ξ = x (* to prevent reevaluation *) in
      (α[fst ξ], β[fst ξ])

where `w[e]` means applying `w` to `e`.

Moreover, WrapConts now have an explanation for better pretty printing.
Though not much.

This commit also fixes a long-standing bug where some sequences of
wrappers were generated backwards. Woops. This was basically impossible
to hit before.
