### PR TITLE
Make 'lazy' a keyword

### DIFF
--- a/compiler/Repl/Display.hs
+++ b/compiler/Repl/Display.hs
@@ -4,6 +4,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Text.Encoding as T
 import qualified Data.Text as T
 import Data.Maybe
+import Data.Char
 
 import qualified Foreign.Lua.Types.Error as L
 import qualified Foreign.Lua.Api.Types as L
@@ -72,9 +73,10 @@ instance Pretty Value where
   pretty (Boolean x) = sliteral . string $ if x then "true" else "false"
   pretty (Opaque x)  = enclose (char '<') (char '>') (keyword x)
   pretty (Constructor x Nothing) = stypeCon (text x)
-  pretty (Constructor x (Just t)) = stypeCon (text x) <+> parensIf t where
+  pretty (Constructor x (Just t)) = colour (text x) <+> parensIf t where
     parensIf x@Constructor{} = parens (pretty x)
     parensIf x = pretty x
+    colour = if isLower (T.head x) then stypeSkol else stypeCon
   pretty (Table m) | isTuple m = parens (hsep (punctuate comma (map pretty vs))) where
     vs = getValues m
     getValues m = case m Map.! T.pack "2" of

--- a/src/Backend/Lua/Postprocess.hs
+++ b/src/Backend/Lua/Postprocess.hs
@@ -69,7 +69,7 @@ genOperator op | op == vLAZY =
            [ LuaFunction [ eks ]
              [ LuaReturn (LuaTable [ (LuaNumber 1, LuaRef eks)
                                    , (LuaNumber 2, LuaFalse)
-                                   , (LuaString "__tag", LuaString "Lazy")
+                                   , (LuaString "__tag", LuaString "lazy")
                                    ]) ] ] where
   eks = LuaName "x"
 genOperator op | op == vForce =

--- a/src/Parser.y
+++ b/src/Parser.y
@@ -62,6 +62,7 @@ import Syntax
   of       { Token TcOf _ _ }
   module   { Token TcModule _ _ }
   open     { Token TcOpen _ _ }
+  lazy     { Token TcLazy _ _ }
 
   ','      { Token TcComma _ _ }
   '.'      { Token TcDot _ _ }
@@ -157,6 +158,7 @@ Expr0 :: { Expr Parsed }
           { withPos2 $1 $3 $ Match (completeTuple Tuple $2) $4 }
       | function ListE1(Arm) '$end'            { withPos1 $1 $ Function $2 }
       | qdotid Atom                            { withPos2 $1 $2 $ OpenIn (getName $1) $2 }
+      | lazy Atom                              { withPos2 $1 $2 $ Lazy $2 }
       | Atom                                   { $1 }
 
 Atom :: { Expr Parsed }
@@ -313,6 +315,7 @@ TypeAtom :: { Located (Type Parsed) }
          | TyVar                                  { lPos1 $1 $ TyVar (getL $1) }
          | Con                                    { lPos1 $1 $ TyPromotedCon (getL $1) }
          | type                                   { lPos1 $1 TyType }
+         | lazy                                   { lPos1 $1 $ TyCon (Name (T.pack "lazy")) }
          | '(' ')'                                { lPos2 $1 $2 $ TyCon (Name (T.pack "unit")) }
          | '(' Type ')'                           { lPos2 $1 $3 (getL $2) }
          | '{' Rows(':', Type) '}'                { lPos2 $1 $3 $ TyExactRows (map (second getL) $2) }

--- a/src/Parser/Lexer.x
+++ b/src/Parser/Lexer.x
@@ -87,6 +87,7 @@ tokens :-
   <0> "of"     { constTok TcOf }
   <0> "module" { constTok TcModule }
   <0> "open"   { constTok TcOpen }
+  <0> "lazy"   { constTok TcLazy }
 
   <0> ","      { constTok TcComma }
   <0> "."      { constTok TcDot }

--- a/src/Parser/Token.hs
+++ b/src/Parser/Token.hs
@@ -35,6 +35,7 @@ data TokenClass
   | TcOf -- of
   | TcModule -- module
   | TcOpen -- open
+  | TcLazy
 
   | TcDot -- .
   | TcComma -- ,
@@ -106,6 +107,7 @@ instance Show TokenClass where
   show TcOf = "of"
   show TcModule = "module"
   show TcOpen = "open"
+  show TcLazy = "lazy"
 
   show TcComma = ","
   show TcDot = "."

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -106,6 +106,9 @@ data Expr p
   -- Module
   | OpenIn (Var p) (Expr p) (Ann p)
 
+  -- Laziness
+  | Lazy (Expr p) (Ann p)
+
   | ExprWrapper (Wrapper p) (Expr p) (Ann p)
 
 deriving instance (Eq (Var p), Eq (Ann p)) => Eq (Expr p)

--- a/src/Syntax/Desugar.hs
+++ b/src/Syntax/Desugar.hs
@@ -69,6 +69,11 @@ desugarProgram = traverse statement where
          $ foldf (\v e -> Fun v e a) args
          $ Tuple tuple a
 
+  expr (Lazy e a) = do
+    e <- expr e
+    pure $ App (VarRef (TgInternal "lazy") a)
+               (Fun (PLiteral LiUnit a) e a)
+               a
   expr (OpenIn _ e _) = expr e
 
   buildTuple :: MonadGen Int m

--- a/src/Syntax/Pretty.hs
+++ b/src/Syntax/Pretty.hs
@@ -6,7 +6,7 @@ module Syntax.Pretty
   ) where
 
 import Control.Arrow (first, second)
-import Control.Lens
+import Control.Lens hiding (Lazy)
 
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -73,6 +73,7 @@ instance (Pretty (Var p)) => Pretty (Expr p) where
   pretty (TupleSection es _) = parens (hsep (punctuate comma (map (maybe (string "") pretty) es)))
 
   pretty (OpenIn v e _) = pretty v <+> string "." <+> parens (pretty e)
+  pretty (Lazy e _) = keyword "lazy" <+> parenArg e
 
   pretty (ExprWrapper wrap ex _) = go wrap ex where
     go (TypeLam v t) ex = keyword "fun" <+> braces (pretty (TySkol v) <+> colon <+> pretty t) <> dot <+> pretty ex

--- a/src/Syntax/Resolve.hs
+++ b/src/Syntax/Resolve.hs
@@ -276,6 +276,7 @@ reExpr r@(OpenIn m e a) =
   resolveOpen m Nothing (\m' -> OpenIn m' <$> reExpr e <*> pure a)
   `catchError` (throwError . wrapError r)
 
+reExpr (Lazy e a) = Lazy <$> reExpr e <*> pure a
 reExpr ExprWrapper{} = error "resolve cast"
 reExpr (InstHole a) = pure $ InstHole a
 

--- a/src/Syntax/Transform.hs
+++ b/src/Syntax/Transform.hs
@@ -90,6 +90,7 @@ transformExpr fe = goE where
   transE (InstHole a) = InstHole a
 
   transE (ExprWrapper w e a) = ExprWrapper w (goE e) a
+  transE (Lazy e a) = Lazy (goE e) a
 
   goE = transE . fe
 
@@ -130,6 +131,7 @@ transformExprTyped fe fc ft = goE where
   transE (InstHole a) = InstHole (goA a)
 
   transE (ExprWrapper w e a) = ExprWrapper (goW w) (goE e) (goA a)
+  transE (Lazy e a) = Lazy (goE e) (goA a)
 
   goW (Cast c) = Cast (goC c)
   goW (TypeApp t) = TypeApp (goT t)
@@ -194,5 +196,6 @@ correct ty (TupleSection es a) = TupleSection es (fst a, ty)
 correct ty (OpenIn n e a) = OpenIn n e (fst a, ty)
 correct ty (InstType t a) = InstType t (fst a, ty)
 correct ty (InstHole a) = InstHole (fst a, ty)
+correct ty (Lazy e a) = Lazy e (fst a, ty)
 
 correct ty (ExprWrapper w e a) = ExprWrapper w e (fst a, ty)

--- a/tests/lazy/lazy01-pass.ml
+++ b/tests/lazy/lazy01-pass.ml
@@ -1,3 +1,3 @@
-let foo = lazy (fun () -> "oh my")
+let foo = lazy "oh my"
 let bar = force foo
 let bar' : string = foo

--- a/tests/lazy/lazy02-fail.ml
+++ b/tests/lazy/lazy02-fail.ml
@@ -1,2 +1,0 @@
-let foo : lazy string = "foo"
-let bar : int = foo

--- a/tests/lazy/lazy02-fail.out
+++ b/tests/lazy/lazy02-fail.out
@@ -1,7 +1,0 @@
-lazy02-fail.ml[2:17 ..2:19]: error
-  Could not match type string with int
-
-  Arising in the expression
-  │ 
-2 │ let bar : int = foo
-  │ 

--- a/tests/lazy/lazy04-pass.ml
+++ b/tests/lazy/lazy04-pass.ml
@@ -3,6 +3,6 @@ let if_then_else c t e =
 
 external val print : string -> unit = "print"
 
-let main = if_then_else true (print "hello there") (lazy (fun x -> x))
+let main = if_then_else true (print "hello there") (lazy ())
 
 (* one branch explicit, one implicit *)

--- a/tests/lazy/lazy04-pass.out
+++ b/tests/lazy/lazy04-pass.out
@@ -1,3 +1,3 @@
-if_then_else : {'l : type}. bool -> lazy 'l -> lazy 'l -> 'l
+if_then_else : {'k : type}. bool -> lazy 'k -> lazy 'k -> 'k
 print : string -> unit
 main : unit

--- a/tests/parser/fail_span.out
+++ b/tests/parser/fail_span.out
@@ -1,5 +1,5 @@
 fail_span.ml[1:12 ..1:16]: error
-  Unexpected "foo", expected one of forall, type, '(', '{', identifier, constructor, type variable
+  Unexpected "foo", expected one of forall, type, lazy, '(', '{', identifier, constructor, type variable
   │ 
 1 │ let main : "foo" = 1
   │ 


### PR DESCRIPTION
Sometimes, the automatic thunking just doesn't work out. E.g.:
```
  (* error : forall 'a. string -> 'a *)
  error "foo" : lazy int
```
generates the constraints
```
  string ~ string
  'a <= lazy int
```
and this becomes `error {lazy int} "foo".`

Typing `lazy (fun () -> ...)` is a lot of work, so this makes it easier.