### PR TITLE
New-type elimination (again)

### DIFF
--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -178,6 +178,7 @@ library amulet
                      , Core.Optimise.Inline
                      , Core.Optimise.Sinking
                      , Core.Optimise.DeadCode
+                     , Core.Optimise.Newtype
                      -- Backend
                      , Backend.Lua
                      , Backend.Lua.Emit

--- a/src/Core/Optimise/Newtype.hs
+++ b/src/Core/Optimise/Newtype.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+module Core.Optimise.Newtype (killNewtypePass) where
+
+import Control.Monad.Namey
+import Control.Monad
+import Control.Lens
+
+import qualified Data.VarMap as V
+import Data.Triple
+
+import Core.Optimise
+import Core.Types
+
+killNewtypePass :: forall a. IsVar a => [Stmt a] -> Namey [Stmt a]
+killNewtypePass = go mempty mempty where
+  go :: V.Map (Atom a) -> V.Map (Coercion a) -> [Stmt a] -> Namey [Stmt a]
+  go ss m (Type n cs:xs) = case cs of
+    [(var, tp)] | Just nt <- isNewtype tp -> do
+      (con, phi, sub) <- newtypeWorker (var, tp) nt
+      (Type n [] :) . (con :) <$> go (ss <> sub) (V.insert (toVar var) phi m) xs
+    _ -> (Type n cs:) <$> go ss m xs
+  go ss m (x@Foreign{}:xs) = (x:) <$> go ss m xs
+  go ss m (StmtLet vs:xs) = do
+    vs' <- goBinding ss m vs
+    (StmtLet vs':) <$> go ss m xs
+  go _ _ [] = pure []
+
+isNewtype :: IsVar a => Type a -> Maybe (Spine a)
+isNewtype (ForallTy Irrelevant from to) = Just $ Spine [(Irrelevant, from)] to
+isNewtype (ForallTy (Relevant var) k t) = do
+  (Spine tys res) <- isNewtype t
+  guard (var `occursInTy` res)
+  pure (Spine ((Relevant var, k):tys) res)
+isNewtype _ = Nothing
+
+newtypeMatch :: IsVar a => V.Map (Coercion a) -> [Arm a] -> Maybe (Coercion a, Arm a)
+newtypeMatch m (it@Arm { _armPtrn = Destr c _, _armTy = ty }:xs)
+  | Just phi@(SameRepr _ cod) <- V.lookup (toVar c) m =
+    case unify cod ty of
+      Just map -> pure (substituteInCo map (Symmetry phi), it)
+      Nothing -> error $ "failed to match newtype-constructor types " ++ show cod ++ " and " ++ show ty
+  | otherwise = newtypeMatch m xs
+newtypeMatch m (_:xs) = newtypeMatch m xs
+newtypeMatch _ [] = Nothing
+
+-- Note: (again) the order of parameters to unify matters! The
+-- substitution is always in terms of the *first* parameter. Here, the
+-- results were backwards, so the solution wasn't being applied properly
+-- and the generated code was wrong.
+
+newtypeWorker :: forall a. IsVar a => (a, Type a) -> Spine a -> Namey (Stmt a, Coercion a, V.Map (Atom a))
+newtypeWorker (cn, tp) (Spine tys cod) = do
+  let CoVar nam id _ = toVar cn
+      (Irrelevant, dom) = last tys
+  let cname = fromVar (CoVar nam id ValueVar)
+      phi = SameRepr dom cod
+  let wrap ((Relevant v, c):ts) ex = Atom . Lam (TypeArgument v c) <$> wrap ts ex
+      wrap [(Irrelevant, c)] ex = do
+        v <- fresh ValueVar
+        Atom . Lam (TermArgument (fromVar v) c) <$> pure (ex (fromVar v) c)
+      wrap _ _ = undefined
+      work var ty = Cast (Ref var ty) phi
+      work :: a -> Type a -> Term a
+      wrap :: [(BoundTv a, Type a)] -> (a -> Type a -> Term a) -> Namey (Term a)
+
+  wrapper <- wrap tys work
+  let con = ( cname, tp, wrapper )
+  pure (StmtLet [con], phi, V.singleton (toVar cn) (Ref (fromVar (CoVar nam id ValueVar)) tp))
+
+goBinding :: forall a. IsVar a => V.Map (Atom a) -> V.Map (Coercion a) -> [(a, Type a, Term a)] -> Namey [(a, Type a, Term a)]
+goBinding ss m = traverse (third3A (fmap (substitute ss) . goTerm)) where
+  goTerm :: Term a -> Namey (Term a)
+  goTerm (Atom x) = Atom <$> goAtom x
+  goTerm (App f x) = App <$> goAtom f <*> goAtom x
+  goTerm (Let (Many vs) e) = Let . Many <$> goBinding ss m vs <*> goTerm e
+  goTerm (Let (One (v, t, e)) b) = do
+    e' <- goTerm e
+    Let (One (v, t, e')) <$> goTerm b
+  goTerm (Extend a as) = Extend <$> goAtom a <*> traverse (third3A goAtom) as
+  goTerm (TyApp f t) = TyApp <$> goAtom f <*> pure t
+  goTerm (Cast f t) = Cast <$> goAtom f <*> pure t
+  goTerm (Match a x) = case newtypeMatch m x of
+    Just (phi, Arm { _armPtrn = Destr _ p, _armBody = bd, _armVars = vs, _armTyvars = tvs }) -> do
+      var <- fresh ValueVar
+      let Just (_, castCodomain) = relates phi
+      bd' <- goTerm (Match (Ref (fromVar var) castCodomain) [Arm { _armPtrn = p, _armTy = castCodomain
+                                                                 , _armBody = bd, _armVars = vs, _armTyvars = tvs }])
+      pure $ Let (One (fromVar var, castCodomain, Cast a phi)) bd'
+    _ -> Match <$> goAtom a <*> traverse (armBody %%~ goTerm) x
+
+  goAtom (Lam arg e) = Lam arg <$> goTerm e
+  goAtom x = pure x
+
+data Spine a =
+  Spine [(BoundTv a, Type a)] (Type a)
+  deriving (Eq, Show, Ord)

--- a/src/Core/Simplify.hs
+++ b/src/Core/Simplify.hs
@@ -4,7 +4,7 @@ module Core.Simplify
 
 import Data.List
 
--- import Core.Optimise.Newtype
+import Core.Optimise.Newtype
 import Core.Optimise.DeadCode
 import Core.Optimise.Inline
 import Core.Optimise.Reduce
@@ -29,7 +29,7 @@ optmOnce = passes where
            , inlineVariablePass
 
            , pure . deadCodePass
-           -- , killNewtypePass
+           , killNewtypePass
 
            , pure . sinkingPass . tagFreeSet
 

--- a/src/Core/Simplify.hs
+++ b/src/Core/Simplify.hs
@@ -21,7 +21,7 @@ lintPasses :: Bool
 lintPasses = True
 
 optmOnce :: [Stmt CoVar] -> Namey [Stmt CoVar]
-optmOnce = passes where
+optmOnce = passes <=< killNewtypePass where
   passes = foldr1 (>=>) $ linted
            [ pure
 
@@ -29,7 +29,6 @@ optmOnce = passes where
            , inlineVariablePass
 
            , pure . deadCodePass
-           , killNewtypePass
 
            , pure . sinkingPass . tagFreeSet
 

--- a/tests/lua/newtype.lua
+++ b/tests/lua/newtype.lua
@@ -1,0 +1,25 @@
+do
+  local __builtin_unit = {
+    ["__tag"] = "__builtin_unit"
+  }
+  local function Foo (en)
+    return en
+  end
+  local function It (x)
+    return {
+      ["__tag"] = "It",
+      [1.0] = x
+    }
+  end
+  local function main (x)
+    x(Foo)
+    x(function (eo)
+      return eo
+    end)
+    x(It)
+    return x(function (ep)
+      return ep
+    end)
+  end
+  main()
+end

--- a/tests/lua/newtype.ml
+++ b/tests/lua/newtype.ml
@@ -1,0 +1,17 @@
+(* Regular, monomorphic type - gets newtyped *)
+type foo = Foo of int
+(* Regular, polymorphic type - gets newtyped *)
+type bar 'a = Bar of 'a
+(* GADT with existentials - no newtyping *)
+type exists =
+  | It : forall 'a. 'a -> exists
+
+(* GADT without existentals - gets newtyped *)
+type gadt 'a =
+  | Mk : int -> gadt int
+
+let main (x : forall 'a. 'a -> unit) =
+  x Foo (* Doesn't get inlined *)
+  x Bar (* Bar's worker has a type argument, so it'll get inlined *)
+  x It (* Doesn't get inlined *)
+  x Mk (* Mk's worker has a type argument, so it'll get inlined *)


### PR DESCRIPTION
Newtype optimisation is back! Now with, hopefully, 100% less broken Core
Lints. I've added a small test about how newtypes are _compiled_ (this
is likely to break in the future if we ever manage to inline
constructors, by the way).

This optimisation is unreasonably efficient in Amulet, considering that
all types with a single constructor (and no existentials) are eligible
for newtype elimination, considering we have no curried constructors.
This includes single-constructor GADTs, since evidence parameters are
currently erased during Lower.

The idea is the same as before: we turn a type like

```ocaml
type foo 'a {
  Foo : forall ('a : *). 'a -> foo 'a
}
```

into a worker like

```ocaml
type foo 'a {}
let Foo : forall ('a : *). 'a -> foo 'a =
  Λ ('a : *). λ(x : 'a). x |> 'a ~ foo 'a
```

which will probably inline everywhere.
