### PR TITLE
Don't run the reduce pass in the REPL

### DIFF
--- a/compiler/Repl.hs
+++ b/compiler/Repl.hs
@@ -217,10 +217,7 @@ runRepl = do
                              (var', tys') = R.extractToplevels resolved
                              ctors = fmap lowerType (Map.restrictKeys (env' ^. T.names . to toMap) (env' ^. constructors))
 
-                         -- We don't perform any complex optimisations, but run one reduction pass in order
-                         -- to get some basic commuting conversion, allowing the codegen to be more
-                         -- effective.
-                         lower <- reducePass <$> runLowerWithCtors ctors (lowerProg prog)
+                         lower <- runLowerWithCtors ctors (lowerProg prog)
                          lastG <- genName
                          pure $ Just ( case last lower of
                                          (C.StmtLet vs) -> map (\(v, t, _) -> (v, t)) vs


### PR DESCRIPTION
The existential example doesn't work in the REPL because of this:
```
> type box =
.   | Box : ('a -> string) * 'a -> box ;;

> let show_it (Box (f, x)) = f x
amc: src/Core/Optimise/Reduce.hs:384:9-50: Irrefutable pattern failed for pattern Just ty
```

@zardyh told me to do this to make Amulet seem like it has contributors.