### PR TITLE
Fix a pattern matching failure when using `force` in the REPL

### DIFF
--- a/src/Backend/Lua/Postprocess.hs
+++ b/src/Backend/Lua/Postprocess.hs
@@ -80,7 +80,7 @@ genOperator op | op == vForce =
                 [ LuaAssign [ LuaIndex (LuaRef eks) (LuaNumber 1)
                             , LuaIndex (LuaRef eks) (LuaNumber 2) ]
                             [ LuaCall (LuaRef (LuaIndex (LuaRef eks) (LuaNumber 1)))
-                               []
+                               [ LuaRef (LuaName "__builtin_unit") ]
                             , LuaTrue]
                   , LuaReturn (LuaRef (LuaIndex (LuaRef eks) (LuaNumber 1))) ] ] ] where
   eks = LuaName "x"


### PR DESCRIPTION
Before:
```
> let pi = lazy (abs (atan (0.0 -. 1.0)) *. 4.0)
pi : lazy float =
 lazy <function>
> force pi
[string "do..."]:6: Pattern matching failure at =stdin[1:10 ..1:46] (ErrRun)
> 
```

After:
```
> let pi = lazy (abs (atan (0.0 -. 1.0)) *. 4.0)
pi : lazy float = lazy <function>
> force pi
_ : float = 3.141592653589793
> 
```