### PR TITLE
Allow open to import implicits into scope

### DIFF
--- a/tests/types/implicits/modules-fail.ml
+++ b/tests/types/implicits/modules-fail.ml
@@ -1,0 +1,6 @@
+module Foo =
+  let implicit x = 1
+
+let foo : int => int = fun x -> x + 1
+
+let main : int = foo

--- a/tests/types/implicits/modules-fail.out
+++ b/tests/types/implicits/modules-fail.out
@@ -1,0 +1,7 @@
+modules-fail.ml[6:18 ..6:20]: error
+  Could not choose implicit value of type int
+
+  Arising in the expression
+  │ 
+6 │ let main : int = foo
+  │ 

--- a/tests/types/implicits/modules-pass.ml
+++ b/tests/types/implicits/modules-pass.ml
@@ -1,0 +1,8 @@
+module Foo =
+  let implicit x = 1
+
+open Foo
+
+let foo : int => int = fun x -> x + 1
+
+let main : int = foo

--- a/tests/types/implicits/modules-pass.out
+++ b/tests/types/implicits/modules-pass.out
@@ -1,0 +1,3 @@
+x : int
+foo : int => int
+main : int


### PR DESCRIPTION
This simply holds a mapping from module names to implicit scopes, with opening looking up the appropriate module and merging it with the current one.